### PR TITLE
Stagger the Expensive Crons

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
-# The Supplejack Worker code is Crown copyright (C) 2014, New Zealand Government, 
-# and is licensed under the GNU General Public License, version 3. 
-# See https://github.com/DigitalNZ/supplejack_worker for details. 
-# 
+# The Supplejack Worker code is Crown copyright (C) 2014, New Zealand Government,
+# and is licensed under the GNU General Public License, version 3.
+# See https://github.com/DigitalNZ/supplejack_worker for details.
+#
 # Supplejack was created by DigitalNZ at the National Library of NZ
 # and the Department of Internal Affairs. http://digitalnz.org/supplejack
 
@@ -50,13 +50,13 @@ group :development do
   gem 'better_errors',      '~> 1.1.0 '
   gem 'guard-rspec'
   gem 'rb-fsevent',         '~> 0.9.1'
-  gem 'pry-rails'
 end
 
 group :development, :test do
   gem 'rspec', '~> 2.14.0'
   gem 'rspec-rails', '~> 2.14.0'
   gem 'factory_girl_rails', '>= 4.1.0'
+  gem 'pry-rails'
 end
 
 group :test do

--- a/app/models/expensive_crons.rb
+++ b/app/models/expensive_crons.rb
@@ -4,21 +4,10 @@
 #
 # Supplejack was created by DigitalNZ at the National Library of NZ
 # and the Department of Internal Affairs. http://digitalnz.org/supplejack
-
-env :PATH, ENV['PATH'] if @enviroment == 'development'
-
-every :day, at: '2:00am' do
-  runner 'HarvestJob.clear_raw_data'
-end
-
-every 5.minutes do
-  runner 'ExpensiveCrons.call'
-end
-
-every 1.day, at: '6:00 am' do
-  runner 'CollectionStatistics.email_daily_stats'
-end
-
-every 2.hours do
-  runner 'EnqueueSourceChecksWorker.perform_async'
+class ExpensiveCrons
+  def self.call
+    HarvestSchedule.create_one_off_jobs
+    HarvestSchedule.create_recurrent_jobs
+    NetworkChecker.check
+  end
 end

--- a/app/workers/api_update_worker.rb
+++ b/app/workers/api_update_worker.rb
@@ -18,7 +18,7 @@ class ApiUpdateWorker < AbstractWorker
       tries = 0
       begin
         if tries < 10
-          response = RestClient::Request.execute(method: :post, url: "#{ENV["API_HOST"]}#{path}", payload: attributes.to_json, timeout: 10, headers: {content_type: :json, accept: :json})
+          response = RestClient::Request.execute(method: :post, url: "#{ENV["API_HOST"]}#{path}", payload: attributes.to_json, timeout: 10, open_timeout: 10, headers: {content_type: :json, accept: :json})
           response = JSON.parse(response)
           @job.set(last_posted_record_id: response["record_id"])
         end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,31 +1,32 @@
-# The Supplejack Worker code is Crown copyright (C) 2014, New Zealand Government, 
-# and is licensed under the GNU General Public License, version 3. 
-# See https://github.com/DigitalNZ/supplejack_worker for details. 
-# 
+# The Supplejack Worker code is Crown copyright (C) 2014, New Zealand Government,
+# and is licensed under the GNU General Public License, version 3.
+# See https://github.com/DigitalNZ/supplejack_worker for details.
+#
 # Supplejack was created by DigitalNZ at the National Library of NZ
 # and the Department of Internal Affairs. http://digitalnz.org/supplejack
 
-if @enviroment == "development"
-  env :PATH, ENV['PATH']
+env :PATH, ENV['PATH'] if @enviroment == 'development'
+
+every :day, at: '2:00am' do
+  runner 'HarvestJob.clear_raw_data'
 end
 
-every :day, at: "2:00am" do
-  runner "HarvestJob.clear_raw_data"
-end
-
-every 5.minutes do
-  runner "HarvestSchedule.create_one_off_jobs"
-  runner "HarvestSchedule.create_recurrent_jobs"
-end
-
-every 1.day, :at => '6:00 am' do
-  runner "CollectionStatistics.email_daily_stats"
+every 3.minutes do
+  runner 'HarvestSchedule.create_one_off_jobs'
 end
 
 every 5.minutes do
-  runner "NetworkChecker.check"
+  runner 'NetworkChecker.check'
+end
+
+every 7.minutes do
+  runner 'HarvestSchedule.create_recurrent_jobs'
+end
+
+every 1.day, at: '6:00 am' do
+  runner 'CollectionStatistics.email_daily_stats'
 end
 
 every 2.hours do
-  runner "EnqueueSourceChecksWorker.perform_async"
+  runner 'EnqueueSourceChecksWorker.perform_async'
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -11,7 +11,7 @@ every :day, at: '2:00am' do
   runner 'HarvestJob.clear_raw_data'
 end
 
-every 5.minutes do
+every 4.minutes do
   runner 'ExpensiveCrons.call'
 end
 

--- a/spec/workers/api_update_worker_spec.rb
+++ b/spec/workers/api_update_worker_spec.rb
@@ -1,7 +1,7 @@
-# The Supplejack Worker code is Crown copyright (C) 2014, New Zealand Government, 
-# and is licensed under the GNU General Public License, version 3. 
-# See https://github.com/DigitalNZ/supplejack_worker for details. 
-# 
+# The Supplejack Worker code is Crown copyright (C) 2014, New Zealand Government,
+# and is licensed under the GNU General Public License, version 3.
+# See https://github.com/DigitalNZ/supplejack_worker for details.
+#
 # Supplejack was created by DigitalNZ at the National Library of NZ
 # and the Department of Internal Affairs. http://digitalnz.org/supplejack
 
@@ -16,17 +16,17 @@ describe ApiUpdateWorker do
 		let(:response) { {record_id: 123}.to_json }
 		before(:each) do
 		  AbstractJob.stub(:find).with(1) {job}
-		  RestClient.stub(:post) { response }
+		  RestClient::Request.stub(:execute) { response }
 		end
 
 		it "should post attributes to the api" do
-		  RestClient.should_receive(:post).with("#{ENV["API_HOST"]}/harvester/records/123/fragments.json", "{}", content_type: :json, accept: :json) { response }
+		  RestClient::Request.should_receive(:execute).with({:method=>:post, :url=>"#{ENV["API_HOST"]}/harvester/records/123/fragments.json", :payload=>"{}", :timeout=>10, :open_timeout=>10, :headers=>{:content_type=>:json, :accept=>:json}}) { response }
 		  worker.perform("/harvester/records/123/fragments.json", {}, 1)
-		end
+	end
 
 		it "should set the jobs last_posted_record_id" do
 			job.should_receive(:set).with({last_posted_record_id: 123})
-		  RestClient.should_receive(:post) { response }
+		  RestClient::Request.should_receive(:execute) { response }
 		  worker.perform("/harvester/records/123/fragments.json", {}, 1)
 		end
 
@@ -37,7 +37,7 @@ describe ApiUpdateWorker do
 
 		it "merges preview=true into attributes if environment is preview" do
 			job.stub(:environment) { "preview" }
-			RestClient.should_receive(:post).with(anything, "{\"preview\":true}", anything) { response }
+			RestClient::Request.should_receive(:execute).with({:method=>:post, :url=>"#{ENV["API_HOST"]}/harvester/records/123/fragments.json", :payload=>"{\"preview\":true}", :timeout=>10, :open_timeout=>10, :headers=>{:content_type=>:json, :accept=>:json}}) { response }
 			worker.perform("/harvester/records/123/fragments.json", {}, 1)
 		end
 	end


### PR DESCRIPTION
*Acceptance criteria*
- CRON jobs on staging and prod are staggered so as to not max out CPU
- CRONS continue to complete successfully
- Before / after monitoring confirms the impact of the change

*Notes*

A cron schedules for the worker on 0a to run the `create_one_of_jobs`, `create_recurrent_jobs` and `NetworkChecker.check` every 5 minutes all at once which puts the server at 100% load for the minute or two they take to run. Possibly look at extending to 7 minutes.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/digitalnz/supplejack_worker/5)
<!-- Reviewable:end -->
