### PR TITLE
Ed/jobs cleaner

### DIFF
--- a/app/models/link_check_job.rb
+++ b/app/models/link_check_job.rb
@@ -8,6 +8,7 @@
 class LinkCheckJob
   include ActiveModel::ForbiddenAttributesProtection
   include Mongoid::Document
+  include Mongoid::Timestamps
   
   field :url,       type: String
   field :record_id, type: Integer
@@ -26,5 +27,5 @@ class LinkCheckJob
   def enqueue
     LinkCheckWorker.perform_async(self.id.to_s) if ENV['LINK_CHECKING_ENABLED'] == 'true'
   end
-
 end
+

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -23,6 +23,6 @@ every 2.hours do
   runner 'EnqueueSourceChecksWorker.perform_async'
 end
 
-every '0 2 28 * *' do
+every :monday, at: '2:30am' do
   rake 'sidekiq_jobs:purge'
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -15,14 +15,17 @@ every 4.minutes do
   runner 'ExpensiveCrons.call'
 end
 
+# Mails the stats for collection to Harvest operator
 every 1.day, at: '6:00 am' do
   runner 'CollectionStatistics.email_daily_stats'
 end
 
+# Checks source LinkCheckRules and suppress/unsuppress conllection.
 every 2.hours do
   runner 'EnqueueSourceChecksWorker.perform_async'
 end
 
+# Clears old Sidekiq Jobs from Mongo
 every :monday, at: '2:30am' do
   rake 'sidekiq_jobs:purge'
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -22,3 +22,7 @@ end
 every 2.hours do
   runner 'EnqueueSourceChecksWorker.perform_async'
 end
+
+every '0 2 28 * *' do
+  rake 'sidekiq_jobs:purge'
+end

--- a/lib/tasks/sidekiq_jobs.rake
+++ b/lib/tasks/sidekiq_jobs.rake
@@ -1,0 +1,8 @@
+namespace :sidekiq_jobs do
+  desc 'Delets all old jobs from Mongo'
+  task purge: :environment do
+    AbstractJob.where(:created_at.lte => (Date.today - 30)).delete_all
+    HarvestJob.where(:created_at.lte => (Date.today - 30)).delete_all
+    LinkCheckJob.where(:created_at.lte => (Date.today - 30)).delete_all
+  end
+end

--- a/lib/tasks/sidekiq_jobs.rake
+++ b/lib/tasks/sidekiq_jobs.rake
@@ -1,8 +1,19 @@
+# The Supplejack Worker code is Crown copyright (C) 2014, New Zealand Government,
+# and is licensed under the GNU General Public License, version 3.
+# See https://github.com/DigitalNZ/supplejack_worker for details.
+#
+# Supplejack was created by DigitalNZ at the National Library of NZ
+# and the Department of Internal Affairs. http://digitalnz.org/supplejack
+
 namespace :sidekiq_jobs do
   desc 'Delets all old jobs from Mongo'
   task purge: :environment do
-    AbstractJob.where(:created_at.lte => (Date.today - 30)).delete_all
-    HarvestJob.where(:created_at.lte => (Date.today - 30)).delete_all
-    LinkCheckJob.where(:created_at.lte => (Date.today - 30)).delete_all
+    AbstractJob.where(:created_at.lte => (Date.today - 7),
+                      environment: 'preview').delete_all
+    
+    AbstractJob.where(:updated_at.lte => (Date.today - 500)).delete_all
+
+    LinkCheckJob.where(:created_at.lte => (Date.today - 7)).delete_all
   end
 end
+

--- a/lib/tasks/sidekiq_jobs.rake
+++ b/lib/tasks/sidekiq_jobs.rake
@@ -6,14 +6,15 @@
 # and the Department of Internal Affairs. http://digitalnz.org/supplejack
 
 namespace :sidekiq_jobs do
-  desc 'Delets all old jobs from Mongo'
+  desc 'Delets old jobs from Mongo'
   task purge: :environment do
-    AbstractJob.where(:created_at.lte => (Date.today - 7),
-                      environment: 'preview').delete_all
-    
+    # Keeping jobs for last 500 days. These are Harvest Jobs
     AbstractJob.where(:updated_at.lte => (Date.today - 500)).delete_all
 
     LinkCheckJob.where(:created_at.lte => (Date.today - 7)).delete_all
+
+    AbstractJob.where(:created_at.lte => (Date.today - 7),
+                      environment: 'preview').delete_all
   end
 end
 


### PR DESCRIPTION
CLEAN UP OLD SIDEKIQ JOBS FROM MONGO

Acceptance Criteria
=================
As a developer i want the jobs that are processed to be deleted from Mongo.
Add timestamp fields to these Jobs if it dosent exist.
Create a cleaner job.
Run the cleaner job once in a week.

Background
=================
Mongo entries created for Sidekiq Jobs were never cleared. The Story aims at clearing these jobs and keeping only a few based on business decisions.

Checklist
=================

- [ ] Code is understandable without Dev
- [ ] Acceptance criteria, what was changed, and why it was changed (If applicable) on Pull / Merge Request
- [ ] All Tests are Passing
- [ ] Code Coverage goes up
- [ ] All new methods have a relevant spec
- [ ] Methods have a single responsibility (Where applicable)
- [ ] Linters Pass
- [ ] ‘Yard’ style comments on methods and classes (Where applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digitalnz/supplejack_worker/11)
<!-- Reviewable:end -->
