### PR TITLE
RETRY SJ HARVEST ERRORS

### DIFF
--- a/app/models/abstract_job.rb
+++ b/app/models/abstract_job.rb
@@ -1,7 +1,7 @@
-# The Supplejack Worker code is Crown copyright (C) 2014, New Zealand Government, 
-# and is licensed under the GNU General Public License, version 3. 
-# See https://github.com/DigitalNZ/supplejack_worker for details. 
-# 
+# The Supplejack Worker code is Crown copyright (C) 2014, New Zealand Government,
+# and is licensed under the GNU General Public License, version 3.
+# See https://github.com/DigitalNZ/supplejack_worker for details.
+#
 # Supplejack was created by DigitalNZ at the National Library of NZ
 # and the Department of Internal Affairs. http://digitalnz.org/supplejack
 
@@ -30,7 +30,9 @@ class AbstractJob
   field :failed_records_count,  type: Integer,  default: 0
   field :posted_records_count,  type: Integer,  default: 0
   field :parser_code,           type: String
-  field :last_posted_record_id,  type: String
+  field :last_posted_record_id, type: String
+  field :retried_records,       type: Array, default: []
+  field :retried_records_count, type: Integer, default: 0
 
   embeds_many :invalid_records
   embeds_many :failed_records
@@ -108,7 +110,7 @@ class AbstractJob
         save
       end
 
-      transitions :from => :ready, :to => :active  
+      transitions :from => :ready, :to => :active
     end
 
     event :finish do

--- a/app/serializers/harvest_job_serializer.rb
+++ b/app/serializers/harvest_job_serializer.rb
@@ -1,7 +1,7 @@
-# The Supplejack Worker code is Crown copyright (C) 2014, New Zealand Government, 
-# and is licensed under the GNU General Public License, version 3. 
-# See https://github.com/DigitalNZ/supplejack_worker for details. 
-# 
+# The Supplejack Worker code is Crown copyright (C) 2014, New Zealand Government,
+# and is licensed under the GNU General Public License, version 3.
+# See https://github.com/DigitalNZ/supplejack_worker for details.
+#
 # Supplejack was created by DigitalNZ at the National Library of NZ
 # and the Department of Internal Affairs. http://digitalnz.org/supplejack
 
@@ -9,7 +9,7 @@ class HarvestJobSerializer < ActiveModel::Serializer
 
   attributes :id, :start_time, :end_time, :records_count, :throughput, :_type
   attributes :created_at, :duration, :status, :status_message, :user_id, :parser_id, :version_id, :environment
-  attributes :failed_records_count, :invalid_records_count, :harvest_schedule_id, :mode, :posted_records_count
+  attributes :failed_records_count, :invalid_records_count, :harvest_schedule_id, :mode, :posted_records_count, :retried_records_count
 
   has_many :failed_records
   has_many :invalid_records

--- a/app/workers/abstract_worker.rb
+++ b/app/workers/abstract_worker.rb
@@ -47,6 +47,11 @@ class AbstractWorker
   def process_response(response)
     # raising an Exception will cause Sidekiq to retry the job.
     unless response['status'] == 'success'
+      # This scenario is because we cannot send an Array to the manager
+      # via Active Resource
+      job.retried_records << response['record_id']
+      job.save!
+      job.set(retried_records_count: job.retried_records.uniq.count)
       raise Supplejack::HarvestError.new(response['message'],
                                          response['backtrace'],
                                          response['raw_data'])

--- a/app/workers/abstract_worker.rb
+++ b/app/workers/abstract_worker.rb
@@ -1,7 +1,7 @@
-# The Supplejack Worker code is Crown copyright (C) 2014, New Zealand Government, 
-# and is licensed under the GNU General Public License, version 3. 
-# See https://github.com/DigitalNZ/supplejack_worker for details. 
-# 
+# The Supplejack Worker code is Crown copyright (C) 2014, New Zealand Government,
+# and is licensed under the GNU General Public License, version 3.
+# See https://github.com/DigitalNZ/supplejack_worker for details.
+#
 # Supplejack was created by DigitalNZ at the National Library of NZ
 # and the Department of Internal Affairs. http://digitalnz.org/supplejack
 
@@ -14,7 +14,7 @@ class AbstractWorker
     job.reload
 
     # When a harvest operator manually stops a job,
-    # it gets finished below, but we cannot (currently) stop the 
+    # it gets finished below, but we cannot (currently) stop the
     # Sidekiq job so this will be executed again with status 'finished'
     # the next time stop_harvest? is called in the loop
     return true if job.finished?
@@ -42,15 +42,9 @@ class AbstractWorker
   end
 
   def process_response(response)
+    # raising an Exception will cause Sidekiq to retry the job.
+    raise Exception unless response['status'] == 'success'
     job.set(last_posted_record_id: response['record_id'])
     job.inc(posted_records_count: 1)
-
-    return if response['status'] == 'success'
-
-    job.failed_records << FailedRecord.new(
-      exception_class: response['exception_class'],
-      message: response['message'],
-      raw_data: response['raw_data']
-    )
   end
 end

--- a/app/workers/api_update_worker.rb
+++ b/app/workers/api_update_worker.rb
@@ -1,7 +1,7 @@
-# The Supplejack Worker code is Crown copyright (C) 2014, New Zealand Government, 
-# and is licensed under the GNU General Public License, version 3. 
-# See https://github.com/DigitalNZ/supplejack_worker for details. 
-# 
+# The Supplejack Worker code is Crown copyright (C) 2014, New Zealand Government,
+# and is licensed under the GNU General Public License, version 3.
+# See https://github.com/DigitalNZ/supplejack_worker for details.
+#
 # Supplejack was created by DigitalNZ at the National Library of NZ
 # and the Department of Internal Affairs. http://digitalnz.org/supplejack
 class ApiUpdateWorker < AbstractWorker

--- a/app/workers/api_update_worker.rb
+++ b/app/workers/api_update_worker.rb
@@ -1,4 +1,6 @@
-# The Supplejack Worker code is Crown copyright (C) 2014, New Zealand Government,
+# frozen_string_literal: true
+
+# The Supplejack Worker code is Crown copyright (C) 2014, New Zealand Government
 # and is licensed under the GNU General Public License, version 3.
 # See https://github.com/DigitalNZ/supplejack_worker for details.
 #
@@ -9,20 +11,20 @@ class ApiUpdateWorker < AbstractWorker
   sidekiq_options queue: 'default', retry: 5, backtrace: true
   sidekiq_retry_in { 5.seconds }
 
-  sidekiq_retries_exhausted do |msg|
+  sidekiq_retries_exhausted do |msg, e|
     Airbrake.notify(msg)
 
     job_id = msg['args'].last
     job = AbstractJob.find(job_id)
 
-    job.inc(posted_records_count: 1)
-
     job.failed_records << FailedRecord.new(
       exception_class: msg['class'],
-      message: msg['error_message'],
-      backtrace: msg['error_backtrace'],
-      raw_data: msg['args'].to_json
+      message: e.message,
+      backtrace: e.backtrace,
+      raw_data: e.raw_data.to_json
     )
+
+    job.inc(posted_records_count: 1)
   end
 
   def perform(path, attributes, job_id)

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,7 +1,7 @@
-# The Supplejack Worker code is Crown copyright (C) 2014, New Zealand Government, 
-# and is licensed under the GNU General Public License, version 3. 
-# See https://github.com/DigitalNZ/supplejack_worker for details. 
-# 
+# The Supplejack Worker code is Crown copyright (C) 2014, New Zealand Government,
+# and is licensed under the GNU General Public License, version 3.
+# See https://github.com/DigitalNZ/supplejack_worker for details.
+#
 # Supplejack was created by DigitalNZ at the National Library of NZ
 # and the Department of Internal Affairs. http://digitalnz.org/supplejack
 
@@ -27,10 +27,10 @@ module HarvesterWorker
 
     # don't generate RSpec tests for views and helpers
     config.generators do |g|
-      
+
       g.test_framework :rspec
       g.fixture_replacement :factory_girl
-      
+
       g.view_specs false
       g.helper_specs false
     end
@@ -40,7 +40,7 @@ module HarvesterWorker
     # -- all .rb files in that directory are automatically loaded.
 
     # Custom directories with classes and modules you want to be autoloadable.
-    config.autoload_paths += %W(#{config.root}/lib #{config.root}/app/workers/concerns)
+    config.autoload_paths += %W(#{config.root}/lib #{config.root}/app/workers/concerns #{config.root}/lib/supplejack)
 
     # Only load the plugins named here, in the order given (default is alphabetical).
     # :all can be used as a placeholder for all plugins not explicitly named.

--- a/lib/supplejack/harvest_error.rb
+++ b/lib/supplejack/harvest_error.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Supplejack
+  # lib/supplejack/exceptions.rb
+  class HarvestError < StandardError
+    attr_reader :message, :backtrace, :raw_data
+
+    def initialize(message, backtrace, raw_data)
+      @message = message
+      @backtrace = backtrace
+      @raw_data = raw_data
+    end
+  end
+end

--- a/spec/lib/supplejack/harvest_error_spec.rb
+++ b/spec/lib/supplejack/harvest_error_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+RSpec.describe Supplejack::HarvestError do
+  describe '#initiliaze' do
+    let(:error) { described_class.new('message', 'backtrace', 'raw_data') }
+    it 'can be initialized with a message' do
+      expect(error.message).to eq 'message'
+    end
+
+    it 'can be initialized with a backtrace' do
+      expect(error.backtrace).to eq 'backtrace'
+    end
+
+    it 'can be initialized with raw data' do
+      expect(error.raw_data).to eq 'raw_data'
+    end
+  end
+end

--- a/spec/workers/api_delete_worker_spec.rb
+++ b/spec/workers/api_delete_worker_spec.rb
@@ -42,6 +42,16 @@ describe ApiDeleteWorker do
       worker.perform('/harvester/records/123/fragments.json', {})
     end
 
+    context 'API return a status: :failed' do
+      before(:each) do
+        RestClient.stub(:put).and_return(failed_response.to_json)
+      end
+
+      it 'raises an exception' do
+        expect { worker.perform('/harvester/records/123/fragments.json', {}) }.to raise_exception
+      end
+    end
+
     context 'API return a status: :success' do
       before(:each) do
         RestClient.stub(:put).and_return(success_response.to_json)

--- a/spec/workers/api_delete_worker_spec.rb
+++ b/spec/workers/api_delete_worker_spec.rb
@@ -42,35 +42,6 @@ describe ApiDeleteWorker do
       worker.perform('/harvester/records/123/fragments.json', {})
     end
 
-    context 'API return a status: :failed' do
-      before(:each) do
-        RestClient.stub(:put).and_return(failed_response.to_json)
-      end
-
-      it 'increments job.posted_records_count' do
-        job.should_receive(:inc).with(posted_records_count: 1)
-        worker.perform('/harvester/records/123/fragments.json', {})
-      end
-
-      it 'updates job.last_posted_record_id' do
-        job.should_receive(:set).with(last_posted_record_id: 123)
-        worker.perform('/harvester/records/123/fragments.json', {})
-      end
-
-      it 'adds a FailedRecord to job.failed_records array' do
-        exception_class = failed_response[:exception_class]
-        message = failed_response[:message]
-        raw_data = failed_response[:raw_data]
-
-        worker.perform('/harvester/records/123/fragments.json', {})
-        failed = job.failed_records.first
-
-        expect(failed.attributes['exception_class']).to eq exception_class
-        expect(failed.attributes['message']).to eq message
-        expect(failed.attributes['raw_data']).to eq raw_data
-      end
-    end
-
     context 'API return a status: :success' do
       before(:each) do
         RestClient.stub(:put).and_return(success_response.to_json)

--- a/spec/workers/api_update_worker_spec.rb
+++ b/spec/workers/api_update_worker_spec.rb
@@ -62,18 +62,6 @@ describe ApiUpdateWorker do
         RestClient.stub(:post).and_return(failed_response.to_json)
       end
 
-      it 'triggers an Airbrake notification' do
-        described_class.within_sidekiq_retries_exhausted_block {
-          expect(Airbrake).to receive(:notify)
-        }
-      end
-
-      it 'creates a new instance of FailedRecord' do
-        described_class.within_sidekiq_retries_exhausted_block {
-          expect(FailedRecord).to receive(:new).with(exception_class: 'ApiUpdateWorker', message: 'An error occured', backtrace: nil, raw_data: '[]')
-        }
-      end
-
       it 'raises Supplejack::HarvestError exception' do
         expect { worker.perform('/harvester/records/123/fragments.json', {}, 1) }.to raise_error(Supplejack::HarvestError)
       end

--- a/spec/workers/api_update_worker_spec.rb
+++ b/spec/workers/api_update_worker_spec.rb
@@ -74,8 +74,8 @@ describe ApiUpdateWorker do
         }
       end
 
-      it 'raises an exception' do
-        expect { worker.perform('/harvester/records/123/fragments.json', {}, 1) }.to raise_exception
+      it 'raises Supplejack::HarvestError exception' do
+        expect { worker.perform('/harvester/records/123/fragments.json', {}, 1) }.to raise_error(Supplejack::HarvestError)
       end
     end
 

--- a/spec/workers/api_update_worker_spec.rb
+++ b/spec/workers/api_update_worker_spec.rb
@@ -74,7 +74,7 @@ describe ApiUpdateWorker do
         }
       end
 
-      it 'raises an exception when it receives a failed response' do
+      it 'raises an exception' do
         expect { worker.perform('/harvester/records/123/fragments.json', {}, 1) }.to raise_exception
       end
     end


### PR DESCRIPTION
Acceptance Criteria
=================

- Harvest errors are retried once (not straight away)
- Retried jobs that are still failing are recorded and displayed on the harvest job page
*Notes*
- Errors are passed back to the end of the queue to be retried later (at the end of the harvest?). eg they should not retry straight away.

Checklist
=================

- [ ] Code is understandable without Dev
- [ ] Acceptance criteria, what was changed, and why it was changed (If applicable) on Pull / Merge Request
- [ ] All Tests are Passing
- [ ] Code Coverage goes up
- [ ] All new methods have a relevant spec
- [ ] Methods have a single responsibility (Where applicable)
- [ ] Linters Pass
- [ ] ‘Yard’ style comments on methods and classes (Where applicable)