### PR TITLE
DISABLE FULL AND FLUSH MODE BUG: As a harvester I want F&F disabled parsers to run scheduled normal harvests, so that I can start using the "disable F&F" functionality

### DIFF
--- a/app/models/harvest_schedule.rb
+++ b/app/models/harvest_schedule.rb
@@ -1,7 +1,7 @@
-# The Supplejack Worker code is Crown copyright (C) 2014, New Zealand Government, 
-# and is licensed under the GNU General Public License, version 3. 
-# See https://github.com/DigitalNZ/supplejack_worker for details. 
-# 
+# The Supplejack Worker code is Crown copyright (C) 2014, New Zealand Government,
+# and is licensed under the GNU General Public License, version 3.
+# See https://github.com/DigitalNZ/supplejack_worker for details.
+#
 # Supplejack was created by DigitalNZ at the National Library of NZ
 # and the Department of Internal Affairs. http://digitalnz.org/supplejack
 
@@ -11,10 +11,10 @@ class HarvestSchedule
   include ActiveModel::SerializerSupport
 
   has_many :harvest_jobs
-  
+
   index status: 1
 
-  field :parser_id,       type: String  
+  field :parser_id,       type: String
   field :start_time,      type: DateTime
   field :cron,            type: String
   field :frequency,       type: String
@@ -36,11 +36,6 @@ class HarvestSchedule
 
   scope :one_off, -> { where(recurrent: false).exists(last_run_at: false) }
   scope :recurrent, -> { where(recurrent: true) }
-
-  def allowed?
-    parser = Parser.find(self.parser_id) rescue nil
-    return !!parser&.allow_full_and_flush
-  end
 
   def self.one_offs_to_be_run
     self.one_off.lte(start_time: Time.now).gte(start_time: Time.now - 6.minutes)
@@ -84,8 +79,6 @@ class HarvestSchedule
   end
 
   def create_job
-    return unless allowed?
-
     if active?
       harvest_jobs.create(parser_id: parser_id,
                           environment: environment,

--- a/spec/models/harvest_schedule_spec.rb
+++ b/spec/models/harvest_schedule_spec.rb
@@ -1,7 +1,7 @@
-# The Supplejack Worker code is Crown copyright (C) 2014, New Zealand Government, 
-# and is licensed under the GNU General Public License, version 3. 
-# See https://github.com/DigitalNZ/supplejack_worker for details. 
-# 
+# The Supplejack Worker code is Crown copyright (C) 2014, New Zealand Government,
+# and is licensed under the GNU General Public License, version 3.
+# See https://github.com/DigitalNZ/supplejack_worker for details.
+#
 # Supplejack was created by DigitalNZ at the National Library of NZ
 # and the Department of Internal Affairs. http://digitalnz.org/supplejack
 
@@ -17,7 +17,7 @@ describe HarvestSchedule do
       s1 = HarvestSchedule.create(start_time: time - 4.minutes, recurrent: false, parser_id: "222", status: 'active')
       s2 = HarvestSchedule.create(start_time: time - 4.minutes, recurrent: true, parser_id: "111", status: 'paused')
       s3 = HarvestSchedule.create(start_time: time - 4.minutes, recurrent: false, parser_id: "333", status: 'inactive')
-    
+
       HarvestSchedule.all.should eq [s1, s2]
     end
   end
@@ -216,24 +216,6 @@ describe HarvestSchedule do
       schedule.reload
       job = schedule.harvest_jobs.last
       job.enrichments.should eq ["ndha_rights"]
-    end
-  end
-
-  describe "#allowed" do
-    let(:schedule) { FactoryGirl.create(:harvest_schedule, parser_id: "1234", environment: "staging") }
-    let(:parser) { double(:parser, parser_id: "1234", allow_full_and_flush: true) }
-    
-    before {
-      Parser.stub(:find) { parser }
-    }  
-
-    it 'returns false if full and flush is not allowed' do
-      parser.stub(:allow_full_and_flush) { false }
-      expect(schedule.allowed?).to be_false
-    end
-
-    it 'returns true if full and flush is allowed' do
-      expect(schedule.allowed?).to be_true
     end
   end
 end


### PR DESCRIPTION
**Acceptance Criteria**

Scheduled harvests run correctly for F&F disabled parsers

**Notes**

I have discussed with Richard
https://boost.sifterapp.com/issues/6870

**Not to be deployed until after NDF.**