### PR TITLE
Update default scope of harvest schedules

### DIFF
--- a/app/models/harvest_schedule.rb
+++ b/app/models/harvest_schedule.rb
@@ -33,7 +33,7 @@ class HarvestSchedule
   before_save :generate_cron
   before_save :generate_next_run_at
 
-  default_scope -> { where(:status.in => %w[active paused]) }
+  default_scope -> { where(:status.in => %w[active paused stopped]) }
 
   scope :one_off, -> { where(recurrent: false).exists(last_run_at: false) }
   scope :recurrent, -> { where(recurrent: true) }


### PR DESCRIPTION
This is part of: https://github.com/DigitalNZ/supplejack_manager/pull/42

*Acceptance Criteria*

Pressing "resume all" after all schedules have been paused does not unpause initially individually paused schedules
Steps to reproduce

http://harvester.dnz0a.digitalnz.org/staging/harvest_schedules
Note the individually paused schedules
Press "Pause all"
Press "Resume all"
Note the original pauses have been lost