### PR TITLE
Update harvest job so that it does not run a full and flush when the records harvested are 0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ group :test do
   gem 'rspec-rails', '~> 3.6'
   gem 'rspec-sidekiq'
   gem 'timecop'
+  gem 'pry-byebug'
 end
 
 group :development do

--- a/app/models/harvest_job.rb
+++ b/app/models/harvest_job.rb
@@ -65,7 +65,7 @@ class HarvestJob < AbstractJob
   end
 
   def finish!
-    flush_old_records if full_and_flush? && (limit.to_i == 0) && !harvest_failure? && !stopped?
+    flush_old_records if full_and_flush_available?
     super
   end
 
@@ -75,5 +75,9 @@ class HarvestJob < AbstractJob
 
   def incremental?
     mode == 'incremental'
+  end
+
+  def full_and_flush_available?
+    full_and_flush? && limit.to_i.zero? && !harvest_failure? && !stopped? && records_count > 0
   end
 end

--- a/spec/models/harvest_job_spec.rb
+++ b/spec/models/harvest_job_spec.rb
@@ -129,6 +129,7 @@ describe HarvestJob do
     end
 
     it 'flushes old records if full_and_flush is true' do
+      job.records_count = 1
       job.should_receive(:flush_old_records)
       job.finish!
     end
@@ -155,6 +156,19 @@ describe HarvestJob do
       job.status = 'stopped'
       job.should_not_receive(:flush_old_records)
       job.finish!
+    end
+  end
+
+  describe '#full_and_flush_available?' do
+    let(:full_and_flush_job) { create(:harvest_job, parser_id: '12345', version_id: '666', records_count: 1, limit: 0, status: 'running', mode: 'full_and_flush') }
+    let(:full_and_flush_job_with_no_records) { create(:harvest_job, parser_id: '12345', version_id: '666', records_count: 0, limit: 0, status: 'running', mode: 'full_and_flush') }
+
+    it 'returns true when the requirements for a full and flush are valid' do
+      expect(full_and_flush_job.full_and_flush_available?).to eq true
+    end
+
+    it 'returns false when the requirements for a full and flush are invalid' do
+      expect(full_and_flush_job_with_no_records.full_and_flush_available?).to eq false
     end
   end
 end


### PR DESCRIPTION
Acceptance Criteria:

If a full and flush harvest finishes with 0 records harvested, the flush is not carried out