### PR TITLE
Add airbrake rescue to ActiveResource Api requests, so we get better understanding of how and when the api fails to respond

### DIFF
--- a/app/models/supplejack_api/record.rb
+++ b/app/models/supplejack_api/record.rb
@@ -9,6 +9,9 @@ module SupplejackApi
 
     def self.find(query, page)
       super(:all, params: { search: query, search_options: page, api_key: ENV['HARVESTER_API_KEY'] })
+    rescue ActiveResource::ServerError => e
+      Aibrake.notify(e, error_message: "The api request failed with: query: #{query} and page: #{page}.  #{e&.message}")
+      raise
     end
   end
 end


### PR DESCRIPTION
Some harvests are not succeeding, and it looks like the ActiveResource Api requests are timing out for particular jobs.  This PR will give us better logging of which records are troublesome, and where in the harvest problems are occurring. 