### PR TITLE
LINK CHECKER COLLECTION SUPPRESSION EMAIL ALERT

### DIFF
--- a/app/mailers/collection_mailer.rb
+++ b/app/mailers/collection_mailer.rb
@@ -10,9 +10,9 @@ class CollectionMailer < ActionMailer::Base
     mail(subject: "Daily Link Checker Collection Report For #{Time.zone.today - 1.day} - #{Rails.env.try(:capitalize)}")
   end
 
-  def collection_status(collection, status)
-    @collection = collection
+  def collection_status(source, status)
+    @source = source
     @status = status
-    mail(subject: "#{collection} is #{status}")
+    mail(subject: "#{source.name} is #{status}")
   end
 end

--- a/app/views/collection_mailer/collection_status.html.erb
+++ b/app/views/collection_mailer/collection_status.html.erb
@@ -1,0 +1,4 @@
+<p>Hello SJ admins</p>
+
+<p>The link-checker has <%= @status %> the source_id <%= @source.id %> at <%= Time.now.in_time_zone %>.</p>
+<p>For more info and options: <%= "#{ENV['MANAGER_HOST']}/#{Rails.env}/suppress_collections" %></p>

--- a/app/views/collection_mailer/collection_status.html.erb
+++ b/app/views/collection_mailer/collection_status.html.erb
@@ -1,4 +1,4 @@
 <p>Hello SJ admins</p>
 
-<p>The link-checker has <%= @status %> the source_id <%= @source.id %> at <%= Time.now.in_time_zone %>.</p>
+<p>The link-checker has <%= @status %> the source_id <%= @source.source_id %> at <%= Time.now.in_time_zone %>.</p>
 <p>For more info and options: <%= "#{ENV['MANAGER_HOST']}/#{Rails.env}/suppress_collections" %></p>

--- a/app/views/collection_mailer/collection_status.text.erb
+++ b/app/views/collection_mailer/collection_status.text.erb
@@ -1,4 +1,4 @@
 Hello SJ admins
 
-The link-checker has <%= @status %> the source_id <%= @source.id %> at <%= Time.now.in_time_zone %>.
+The link-checker has <%= @status %> the source_id <%= @source.source_id %> at <%= Time.now.in_time_zone %>.
 For more info and options: <%= "#{ENV['MANAGER_HOST']}/#{Rails.env}/suppress_collections" %>

--- a/app/views/collection_mailer/collection_status.text.erb
+++ b/app/views/collection_mailer/collection_status.text.erb
@@ -1,1 +1,4 @@
-<%= "#{@collection} is #{@status}" %>
+Hello SJ admins
+
+The link-checker has <%= @status %> the source_id <%= @source.id %> at <%= Time.now.in_time_zone %>.
+For more info and options: <%= "#{ENV['MANAGER_HOST']}/#{Rails.env}/suppress_collections" %>

--- a/app/workers/source_check_worker.rb
+++ b/app/workers/source_check_worker.rb
@@ -45,13 +45,13 @@ class SourceCheckWorker
     # rubocop:disable Metrics/LineLength
     RestClient.put("#{ENV['API_HOST']}/harvester/sources/#{source.id}", source: { status: 'suppressed', status_updated_by: 'LINK CHECKER' }, api_key: ENV['HARVESTER_API_KEY'])
     # rubocop:enable Metrics/LineLength
-    CollectionMailer.collection_status(source.name, 'down')
+    CollectionMailer.collection_status(source, 'suppressed').deliver
   end
 
   def activate_collection
     # rubocop:disable Metrics/LineLength
     RestClient.put("#{ENV['API_HOST']}/harvester/sources/#{source.id}", source: { status: 'active', status_updated_by: 'LINK CHECKER' }, api_key: ENV['HARVESTER_API_KEY'])
     # rubocop:enable Metrics/LineLength
-    CollectionMailer.collection_status(source.name, 'up')
+    CollectionMailer.collection_status(source, 'activated').deliver
   end
 end

--- a/spec/workers/source_check_worker_spec.rb
+++ b/spec/workers/source_check_worker_spec.rb
@@ -131,7 +131,9 @@ describe SourceCheckWorker do
   describe '#suppress_collection' do
     before do
       RestClient.stub(:put)
-      CollectionMailer.stub(:collection_status).with('name', 'down')
+      mailer = double()
+      mailer.stub(:deliver)
+      CollectionMailer.stub(:collection_status).with(source, 'suppressed').and_return(mailer)
     end
 
     it 'should suppress the collection setting the status_updated_by as LINK CHECKER' do
@@ -140,15 +142,17 @@ describe SourceCheckWorker do
     end
 
     it 'should send an email that the collection is down' do
+      expect(CollectionMailer).to receive(:collection_status).with(source, 'suppressed')
       worker.send(:suppress_collection)
-      expect(CollectionMailer).to have_received(:collection_status).with('name', 'down')
     end
   end
 
   describe '#activate_collection' do
     before do
       RestClient.stub(:put)
-      CollectionMailer.stub(:collection_status).with('name', 'up')
+      mailer = double()
+      mailer.stub(:deliver)
+      CollectionMailer.stub(:collection_status).with(source, 'activated').and_return(mailer)
     end
 
     it 'should activate the collection and set the status_updated_by as LINK CHECKER' do
@@ -157,8 +161,8 @@ describe SourceCheckWorker do
     end
 
     it 'should send an email that the collection is down' do
+      expect(CollectionMailer).to receive(:collection_status).with(source, 'activated')
       worker.send(:activate_collection)
-      expect(CollectionMailer).to have_received(:collection_status).with('name', 'up')
     end
   end
 end


### PR DESCRIPTION
As a Harvest Admin I want to be informed when a collection has been suppressed by the link checker, so that I can double-check and take any required actions

**Acceptance Criteria**
- An email is sent to harvest admin's every time a collection is suppressed by the linkchecker