### PR TITLE
single record enrichments only send record id to query api

### DIFF
--- a/app/models/enrichment_job.rb
+++ b/app/models/enrichment_job.rb
@@ -9,6 +9,7 @@ class EnrichmentJob < AbstractJob
   field :enrichment,  type: String
   field :record_id,   type: Integer
 
+  validates :record_id, numericality: { other_than: 0, allow_nil: true, message: 'record_id cannot be zero' }
   validates_uniqueness_of :enrichment,
                           scope: %i[environment status _type parser_id],
                           message: I18n.t('job.already_running', type: 'Enrichment'), if: :active?

--- a/app/models/supplejack_api/record.rb
+++ b/app/models/supplejack_api/record.rb
@@ -8,6 +8,8 @@ module SupplejackApi
     include Enrichable
 
     def self.find(query, page)
+      Rails.logger.info "query: #{query}"
+      Rails.logger.info "page: #{page}"
       super(:all, params: { search: query, search_options: page, api_key: ENV['HARVESTER_API_KEY'] })
     rescue ActiveResource::ServerError => e
       Airbrake.notify(e, error_message: "The api request failed with: query: #{query} and page: #{page}.  #{e&.message}")

--- a/app/workers/enrichment_worker.rb
+++ b/app/workers/enrichment_worker.rb
@@ -68,7 +68,7 @@ class EnrichmentWorker < AbstractWorker
       end
     else
       klass = job.preview? ? SupplejackApi::PreviewRecord : SupplejackApi::Record
-      klass.find({ record_id: job.record_id, 'fragments.source_id' => job.parser.source.source_id }, page: page)
+      klass.find({ record_id: job.record_id }, page: page)
     end
   end
 

--- a/spec/workers/enrichment_worker_spec.rb
+++ b/spec/workers/enrichment_worker_spec.rb
@@ -143,7 +143,7 @@ describe EnrichmentWorker do
       before { job.stub(:record_id) { 'abc123' } }
 
       it 'should fetch a specific record' do
-        expect(SupplejackApi::Record).to receive(:find).with({ record_id: job.record_id, 'fragments.source_id' => 'nlnzcat' }, page: 1)
+        expect(SupplejackApi::Record).to receive(:find).with({ record_id: job.record_id }, page: 1)
         worker.fetch_records(1)
       end
 
@@ -151,7 +151,7 @@ describe EnrichmentWorker do
         before { job.stub(:preview?) { true } }
 
         it 'should fetch a specific record from the preview_records collection' do
-          expect(SupplejackApi::PreviewRecord).to receive(:find).with({record_id: job.record_id, 'fragments.source_id' => 'nlnzcat'}, page: 0)
+          expect(SupplejackApi::PreviewRecord).to receive(:find).with({record_id: job.record_id}, page: 0)
           worker.fetch_records
         end
       end


### PR DESCRIPTION
Single record enrichments seem to time out on the api.  This PR should make it easier for the api to find the record quicker.

Two stories here

**Acceptance Criteria**
- Investigate enrichment retries code for connection to issues with manual enrichments

I have a feeling that the enrichment retries work from the 11th June has introduced some issues. The Airbrake screenshot shows the `TypeError: no implicit conversion of nil into String` error jumping on the 11th.
https://digitalnz.airbrake.io/projects/96483/groups/2173666659557850722?dur=90d%2F1d&last_n=90&filters=%7B%22errors.0.function%22:%224014370043293673100%22%7D&tab=overview
The changes app screenshot shows all prod deploys from 10th to 12th of June. 

Previous write up:
https://basecamp.com/1723294/projects/8491945/messages/79451851

**Notes**
This shows that regular enrichments run after harvests work fine. 
http://harvester.dnz0a.digitalnz.org/production/enrichment_jobs/5b4f145d147d7b3bb2177939
Taking the "Last posted record ID" from above 39656918 to run an enrichment on a single record as follows:
- go here http://harvester.dnz0a.digitalnz.org/parsers/5555718e297b1f941f000002/versions/57e2f570297b1f0df2000001
- Click [ Run Enrichment ]
- Click [ Staging Enrichment ]
- Enter the record id 39210518
- Select the enrichment radio box
- Click [ Start Enrichment ]

**Potentially Related problem**
STAGING HARVEST JOB RETRIES ARE BLOCKING PROD SJ JOBS 
https://www.pivotaltracker.com/story/show/159224433



**Acceptance Criteria**
- Investigate previous >50 second timeout issues 
(eg if they are still occurring in the system)
- Investigate any further timeouts (maybe > 30 seconds?)
- Consider reducing the timeout (that was triggering 504's)  down from 50 seconds
- Draft any follow up stories


*Notes*
- Run this on the API logs to find out how many requests took longer than 50 secs to return a result.
`zcat production.log*gz | grep "duration=\([5-9][0-9][0-9][0-9][0-9]\|[0-9][0-9][0-9][0-9][0-9][0-9]\)" > /tmp/api-dnz04-requests.log`
- https://docs.google.com/spreadsheets/d/1v2eyubZ-RNIj1HWqEb92IsZeaYY3h11mbMxdKsm6MKQ/edit?usp=sharing
- Example of an enrichment it would be great if we could get working http://harvester.dnz0a.digitalnz.org/production/enrichment_jobs/5b4820b0147d7b16db7acb22