### PR TITLE
Remove connection of concepts data being stored in the APIs mongo db

### DIFF
--- a/app/models/supplejack_api/concept.rb
+++ b/app/models/supplejack_api/concept.rb
@@ -6,8 +6,6 @@ module SupplejackApi
     include Mongoid::Document
     include Mongoid::Attributes::Dynamic
 
-    store_in client: 'api', collection: 'concepts'
-
     index concept_id: 1
 
     embeds_many :fragments, cascade_callbacks: true,


### PR DESCRIPTION
*Assumption* - This direct Mongo connection is blocking us getting SJ into the cloud?

*Acceptance criteria*
- Confirm what functionality requires this connection (eg what would die if we turned it off, in case we dont need to support it for now)
- Existing functionality is maintained with no mongo api connection:
 - https://digitalnz.org/explore
 - https://digitalnz.org/concepts/4051
 - https://digitalnz.org/records?i%5Bconcept_ids%5D=4051&text=water
 - Regular harvesting (eg nothing directly to do with concepts)
