### PR TITLE
Add index to start_time field for AbstractJob

### DIFF
--- a/app/models/abstract_job.rb
+++ b/app/models/abstract_job.rb
@@ -7,7 +7,7 @@ class AbstractJob
   include Mongoid::Attributes::Dynamic
   include AASM
 
-  index status: 1
+  index status: 1, start_time: 1
 
   field :start_time,            type: DateTime
   field :end_time,              type: DateTime


### PR DESCRIPTION
Resolve memory problems by adding another index to the abstract job model.

`Executor error during find command: OperationFailed: Sort operation used more than the maximum 33554432 bytes of RAM. Add an index, or specify a smaller limit. (96)`
