### PR TITLE
PREVENT TOO MANY PREVIEW WORKERS: As Dan I want SJ to prevent  multiple preview jobs from silently running in the background, so that the queue's don't get overloaded and content partner sites don't get spammed by preview requests

### DIFF
--- a/app/workers/preview_worker.rb
+++ b/app/workers/preview_worker.rb
@@ -29,10 +29,12 @@ class PreviewWorker < HarvestWorker
 
     preview.update_attribute(:status, 'Worker starting. Loading parser and fetching data...')
 
-    job.records do |record, i|
-      next if i < job.index
-      process_record(record)
-      enrich_record(record)
+    unless stop_harvest?
+      job.records do |record, i|
+        next if i < job.index
+        process_record(record)
+        enrich_record(record)
+      end
     end
 
     job.finish!

--- a/spec/workers/preview_worker_spec.rb
+++ b/spec/workers/preview_worker_spec.rb
@@ -26,6 +26,7 @@ describe PreviewWorker do
       worker.stub(:process_record)
       worker.stub(:enrich_record)
       job.stub(:finish!)
+      worker.stub(:stop_harvest?) { false }
     end
 
     it 'is a critical job' do
@@ -73,6 +74,18 @@ describe PreviewWorker do
       it 'should update the preview object with validation errors' do
         expect(preview).to receive(:update_attribute).with(:harvest_failure, job.harvest_failure.to_json)
         worker.perform('abc123', 'preview123')
+      end
+    end
+
+    context 'stopped jobs' do
+      before { worker.stub(:stop_harvest?) { true } }
+
+      it 'does not call preview_record if the job is stopped' do
+        expect(worker).to_not receive(:process_record)
+      end
+
+      it 'does not call enrich_record if the job is stopped' do
+        expect(worker).to_not receive(:enrich_record)
       end
     end
   end


### PR DESCRIPTION
**Acceptance Criteria**
- The problem of multiple previews running at once is prevented or able to be mitigated/fixed

**Notes**
SJ worker `preview_worker.rb:26`

`PreviewWorker#perform` has a big where it does not stop guard this method from executing if the AbstractJob it is about to run has `'status': 'finished'`

`AbstractWorker#stop_harvest?` is used in `HarvestWorker` class to protect Sidekiq from processing jobs that have actually finished and not end up in a loop of jobs infinitely being 'busy' in Sidekiq, like in this meteor: https://www.pivotaltracker.com/story/show/159946180
