### PR TITLE
REMOVE THE WHOLE CONCEPT FROM 'SOURCE NAMES' IN SJ

### DIFF
--- a/app/mailers/collection_mailer.rb
+++ b/app/mailers/collection_mailer.rb
@@ -13,6 +13,6 @@ class CollectionMailer < ActionMailer::Base
   def collection_status(source, status)
     @source = source
     @status = status
-    mail(subject: "#{source.name} is #{status}")
+    mail(subject: "#{source.source_id} is #{status}")
   end
 end

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -6,7 +6,6 @@ class Source < ActiveResource::Base
   headers['Authorization'] = "Token token=#{ENV['WORKER_KEY']}"
 
   schema do
-    attribute :name,                :string
     attribute :partner_id,          :string
     attribute :source_id,           :string
     attribute :collection_rules_id, :string

--- a/spec/models/parser_version_spec.rb
+++ b/spec/models/parser_version_spec.rb
@@ -5,7 +5,7 @@ describe ParserVersion do
   let(:parser) { Parser.new(name: 'Europeana', id: '123', data_type: 'Record', source: source) }
   let(:parser_version) { ParserVersion.new(parser_id: '123') }
   let(:job) { mock_model(HarvestJob).as_null_object }
-  let(:source) { Source.new(name: 'source_name') }
+  let(:source) { Source.new(source_id: 'source_name') }
 
   describe '#last_harvested_at' do
     let!(:time) { Time.now }

--- a/spec/workers/source_check_worker_spec.rb
+++ b/spec/workers/source_check_worker_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe SourceCheckWorker do
   let(:worker) { SourceCheckWorker.new }
-  let(:source) { double(:source, name: 'name', source_id: 'source_id', id: 'abc123') }
+  let(:source) { double(:source, source_id: 'source_id', id: 'abc123') }
 
   before(:each) do
     worker.instance_variable_set(:@primary_collection, 'NAME')


### PR DESCRIPTION
**Acceptance Criteria**

- Source Names are completely removed from SJ (front and back end)
- Source ID is used directly in all cases where Source Name previously was
