### PR TITLE
SETUP SEPARATE SIDEKIQ QUEUES OUT OF THE BOX

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -17,6 +17,7 @@ development:
   LINK_CHECKING_ENABLED: "true"
   LINKCHECKER_RECIPIENTS: "test@test.com"
   WORKER_KEY: YOUR_WORKER_KEY
+  REDIS_URL: 'redis://localhost:6379/2'
 
 test:
   API_HOST: "http://127.0.0.1:3000"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
       - .:/var/worker/:cached
     command: bash -c " rm tmp/pids/server.pid; bundle exec rails s -b 0.0.0.0 -p 3002"
     environment:
-      - REDIS_URL=redis://redis_host:6379
+      - REDIS_URL=redis://redis_host:6379/2
     depends_on:
       - mongo
       - sidekiq
@@ -32,7 +32,7 @@ services:
       - .:/var/worker/:cached
     command: bash -c " rm tmp/pids/sidekiq.pid; bundle exec sidekiq"
     environment:
-      - REDIS_URL=redis://redis_host:6379
+      - REDIS_URL=redis://redis_host:6379/2
     depends_on:
       - redis
 


### PR DESCRIPTION
Supplejack has it’s own instance of Sidekiq that you will need to run for the Full and Flush harvest to work. Start Sidekiq from the api directory with bundle exec sidekiq. If you are running both Sidekiq instances on the same machine, you will need to point them at separate Redis databases otherwise you will end up in problems where the two Sidekiqs are trying to process each others jobs. This can be done by appending /<number> to the end of your Redis URL.