### PR TITLE
Fix OAI Parser Scripts

### DIFF
--- a/app/models/parser.rb
+++ b/app/models/parser.rb
@@ -6,13 +6,4 @@ class Parser < ActiveResource::Base
 
   self.site = ENV['MANAGER_HOST']
   headers['Authorization'] = "Token token=#{ENV['WORKER_KEY']}"
-
-  def last_harvested_at
-    job = harvest_jobs.first
-    job ? job.start_time : nil
-  end
-
-  def harvest_jobs
-    HarvestJob.where(parser_id: id).desc(:start_time)
-  end
 end

--- a/app/models/parser_version.rb
+++ b/app/models/parser_version.rb
@@ -10,16 +10,16 @@ class ParserVersion < ActiveResource::Base
   self.element_name = 'version'
 
   def last_harvested_at
-    job = harvest_jobs('finished')[1]
-    job ? job.start_time : nil
-  end
+    last_finished_harvest_job = HarvestJob.desc(:start_time)
+      .find_by(
+      parser_id: parser_id,
+      status: 'finished',
+      environment: { '$ne': 'preview' }
+    )
 
-  def harvest_jobs(status = nil)
-    if status == 'finished'
-      HarvestJob.where(parser_id: parser_id, status: status).desc(:start_time)
-    else
-      HarvestJob.where(parser_id: parser_id).desc(:start_time)
-    end
+    last_finished_harvest_job.start_time
+  rescue Mongoid::Errors::DocumentNotFound
+    nil
   end
 
   def parser_id

--- a/app/models/parser_version.rb
+++ b/app/models/parser_version.rb
@@ -10,16 +10,11 @@ class ParserVersion < ActiveResource::Base
   self.element_name = 'version'
 
   def last_harvested_at
-    last_finished_harvest_job = HarvestJob.desc(:start_time)
-                                          .find_by(
-                                            parser_id: parser_id,
-                                            status: 'finished',
-                                            environment: { '$ne': 'preview' }
-                                          )
-
-    last_finished_harvest_job.start_time
-  rescue Mongoid::Errors::DocumentNotFound
-    nil
+    HarvestJob.where(
+      parser_id: parser_id,
+      status: 'finished',
+      environment: { '$ne': 'preview' }
+    ).max(:start_time)
   end
 
   def parser_id

--- a/app/models/parser_version.rb
+++ b/app/models/parser_version.rb
@@ -11,11 +11,11 @@ class ParserVersion < ActiveResource::Base
 
   def last_harvested_at
     last_finished_harvest_job = HarvestJob.desc(:start_time)
-      .find_by(
-      parser_id: parser_id,
-      status: 'finished',
-      environment: { '$ne': 'preview' }
-    )
+                                          .find_by(
+                                            parser_id: parser_id,
+                                            status: 'finished',
+                                            environment: { '$ne': 'preview' }
+                                          )
 
     last_finished_harvest_job.start_time
   rescue Mongoid::Errors::DocumentNotFound

--- a/spec/models/parser_spec.rb
+++ b/spec/models/parser_spec.rb
@@ -21,22 +21,4 @@ describe Parser do
       parser.load_file(:staging)
     end
   end
-
-  describe '#last_harvested_at' do
-    let!(:time) { Time.now }
-    let!(:job1) { create(:harvest_job, start_time: time - 1.day, parser_id: '12', status: 'finished') }
-    let!(:job2) { create(:harvest_job, start_time: time - 2.day, parser_id: '12', status: 'finished') }
-
-    it 'returns the last date a harvest job was run' do
-      Timecop.freeze(time) do
-        parser = Parser.new(id: '12', name: 'Europeana')
-        expect(parser.last_harvested_at.to_i).to eq (time - 1.day).to_i
-      end
-    end
-
-    it 'returns nil when no job has been run' do
-      parser = Parser.new(id: '123', name: 'Europeana')
-      expect(parser.last_harvested_at).to be_nil
-    end
-  end
 end


### PR DESCRIPTION
OAI type Parser script was not working properly when the `Incremental` flag was on.

- Update `last_harvested_at logic` so that it only considers `HarvestJobs` that are not `preview`. We also updated how the `last_harvested_at` value was being retrieved, we had a bug where we were using `Array[1]` to get the `first` item of the array rather than `Array[0]`.

- Remove `last_harvested_at` functionally from `Parser` class, as it was never used. When a parser is read, its content must come from the `ParserVersion` class.