### PR TITLE
Revert supplejack_common#43

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'rails', '~> 5.2.4'
 gem 'responders'
 gem 'sidekiq', '~> 5.2.3'
 gem 'sinatra', require: nil
-gem 'supplejack_common', github: 'DigitalNZ/supplejack_common', tag: 'v2.8.2'
+gem 'supplejack_common', github: 'DigitalNZ/supplejack_common', tag: 'v2.8.3'
 gem 'whenever', require: false
 gem 'brakeman'
 gem 'moderate_parameters'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DigitalNZ/supplejack_common
-  revision: b409a080018e7f635b08ea475ffae646cca42498
-  tag: v2.8.2
+  revision: a866415515ee9513caf8bdf67765a401e2458a1c
+  tag: v2.8.3
   specs:
     supplejack_common (0.0.2)
       actionpack


### PR DESCRIPTION
Revert https://github.com/DigitalNZ/supplejack_common/pull/43 (via as per https://github.com/DigitalNZ/supplejack_common/pull/44) as it incorrectly encodes all `+` characters, making URLs like `https://api.digitalnz.org/records.xml?api_key=v0aORgQAmQDSPtOJzMGI&text=dc_identifier_sm:"emu:552455"+OR+dc_identifier_sm...` into &text=dc_identifier_sm:"emu:552455"%2BOR%2Bdc_identifier_sm...`