### PR TITLE
MOVE SES TO SYDNEY: As James, I want the SES service in Sydney to be used, so that we can keep things tidy in one place

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,11 +60,14 @@ Rails.application.configure do
     address: ENV['SMTP_ADDRESS'],
     domain: ENV['SMTP_DOMAIN'],
     port: ENV['SMTP_PORT'],
-    user_name: ENV['SMTP_USER_NAME'],
+    user_name: ENV['SMTP_USER'],
     password: ENV['SMTP_PASSWORD']
   }
 
-  config.action_mailer.default_url_options = { host: ENV['HOST'] }
+  config.action_mailer.default_url_options = {
+    host: ENV['HOST'],
+    protocol: 'https'
+  }
 
   config.log_level = ENV['LOG_LEVEL'] || :info
   config.log_tags = [:request_id]

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -60,11 +60,14 @@ Rails.application.configure do
     address: ENV['SMTP_ADDRESS'],
     domain: ENV['SMTP_DOMAIN'],
     port: ENV['SMTP_PORT'],
-    user_name: ENV['SMTP_USER_NAME'],
+    user_name: ENV['SMTP_USER'],
     password: ENV['SMTP_PASSWORD']
   }
 
-  config.action_mailer.default_url_options = { host: ENV['HOST'] }
+  config.action_mailer.default_url_options = {
+    host: ENV['HOST'],
+    protocol: 'https'
+  }
 
   config.log_level = ENV['LOG_LEVEL'] || :info
   config.log_tags = [:request_id]

--- a/config/environments/uat.rb
+++ b/config/environments/uat.rb
@@ -60,11 +60,14 @@ Rails.application.configure do
     address: ENV['SMTP_ADDRESS'],
     domain: ENV['SMTP_DOMAIN'],
     port: ENV['SMTP_PORT'],
-    user_name: ENV['SMTP_USER_NAME'],
+    user_name: ENV['SMTP_USER'],
     password: ENV['SMTP_PASSWORD']
   }
 
-  config.action_mailer.default_url_options = { host: ENV['HOST'] }
+  config.action_mailer.default_url_options = {
+    host: ENV['HOST'],
+    protocol: 'https'
+  }
 
   config.log_level = ENV['LOG_LEVEL'] || :info
   config.log_tags = [:request_id]


### PR DESCRIPTION
[MOVE SES TO SYDNEY: As James, I want the SES service in Sydney to be used, so that we can keep things tidy in one place](https://www.pivotaltracker.com/story/show/171917726)

STORY
=====

**Acceptance Criteria**
- The SES service is hosted on Sydney instead of us-west-2
- Every services using SES are using Sydney

**Note**
- Remove other SES services
- Align environment variable names
