### PR TITLE
FIX LINK CHECK SOURCE

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ git_source(:github) { |repo| "https://github.com/#{repo}" }
 gem 'aasm'
 gem 'active_model_serializers', '~> 0.10.7'
 gem 'activeresource', require: 'active_resource'
-gem 'aws-sdk-s3', '~> 1'
 gem 'chronic'
 gem 'figaro'
 gem 'kaminari'
@@ -29,6 +28,11 @@ gem 'amazing_print'
 gem 'mimemagic', '= 0.3.10'
 gem "rexml", ">= 3.2.5"
 gem 'elastic-apm'
+
+
+# AWS gems required by parsers
+gem 'aws-sdk-s3', '~> 1'
+gem 'aws-sdk-rekognition', '~> 1.59'
 
 group :test do
   gem 'database_cleaner-mongoid'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,9 @@ GEM
     aws-sdk-kms (1.50.0)
       aws-sdk-core (~> 3, >= 3.121.2)
       aws-sigv4 (~> 1.1)
+    aws-sdk-rekognition (1.59.0)
+      aws-sdk-core (~> 3, >= 3.121.2)
+      aws-sigv4 (~> 1.1)
     aws-sdk-s3 (1.104.0)
       aws-sdk-core (~> 3, >= 3.121.2)
       aws-sdk-kms (~> 1)
@@ -426,6 +429,7 @@ GEM
     zeitwerk (2.5.1)
 
 PLATFORMS
+  x86_64-darwin-19
   x86_64-darwin-20
   x86_64-linux
 
@@ -434,6 +438,7 @@ DEPENDENCIES
   active_model_serializers (~> 0.10.7)
   activeresource
   amazing_print
+  aws-sdk-rekognition (~> 1.59)
   aws-sdk-s3 (~> 1)
   brakeman
   chronic

--- a/app/models/link_check_job.rb
+++ b/app/models/link_check_job.rb
@@ -15,12 +15,15 @@ class LinkCheckJob
   validates :url, :record_id, :source_id, presence: true
 
   def source
-    Source.find(:all, params: { source: { source_id: source_id } }).first
+    Source.find(source_id)
+  rescue ActiveResource::ResourceNotFound
+    nil
   end
 
   private
     def enqueue
       return unless ENV['LINK_CHECKING_ENABLED'] == 'true'
+
       LinkCheckWorker.perform_async(id.to_s)
     end
 end

--- a/spec/models/link_check_job_spec.rb
+++ b/spec/models/link_check_job_spec.rb
@@ -44,4 +44,12 @@ describe LinkCheckJob do
       link_check_job.send(:enqueue)
     end
   end
+
+  describe '#source' do
+    it 'calls source find' do
+      expect(Source).to receive(:find).with(link_check_job.source_id)
+
+      link_check_job.source
+    end
+  end
 end


### PR DESCRIPTION
**Acceptance Criteria**
The LinkCheck Worker does not crash the Manager when doing a lot of checking.

**Issue**
Worker was requesting all the sources from the manager when it only requires a single source fetched with source_id.

**Changes**
Manager `SourceController#show` has a custom_find method that finds source with either id or source_id. So worker can just find source with `source_id`.