### PR TITLE
API KEY IN HEADER FOR SJ WORKER: As Sasha, I want Supplejack Worker to use HTTP-header based authentication for making API requests, so that the API keys are kept secret.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@
 .idea/*
 id_rsa
 .powder
+/spec/examples.txt
 
 # Vendor Cache
 vendor/cache

--- a/app/api/api/record.rb
+++ b/app/api/api/record.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Api
+  class Record
+    def self.flush(params)
+      Api::Request.new(
+        '/harvester/records/flush',
+        params
+      ).post
+    end
+
+    def self.put(record_id, params)
+      Api::Request.new(
+        "/harvester/records/#{record_id}",
+        params
+      ).put
+    end
+
+    def self.delete(id)
+      Api::Request.new(
+        '/harvester/records/delete',
+        { id: id }
+      ).put
+    end
+  end
+end

--- a/app/api/api/request.rb
+++ b/app/api/api/request.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Api
+  class Request
+    attr_reader :url, :token, :params
+
+    def initialize(path, params = {})
+      @url = "#{ENV['API_HOST']}#{path}.json"
+      @token = ENV['HARVESTER_API_KEY']
+      @params = params
+    end
+
+    def get
+      execute(:get)
+    end
+
+    def post
+      execute(:post)
+    end
+
+    def put
+      execute(:put)
+    end
+
+    def patch
+      execute(:patch)
+    end
+
+    def delete
+      execute(:delete)
+    end
+
+    private
+      def execute(method)
+        if method.in?(%i[post put patch])
+          payload = @params
+          url_params = {}
+        else
+          payload = nil
+          url_params = @params
+        end
+
+        RestClient::Request.execute(
+          method: method,
+          url: @url,
+          payload: payload,
+          headers: {
+            'Authentication-Token': @token
+          }.merge(url_params)
+        )
+      end
+  end
+end

--- a/app/api/api/source.rb
+++ b/app/api/api/source.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Api
+  class Source
+    def self.get(source_id)
+      Api::Request.new(
+        "/harvester/sources/#{source_id}"
+      ).get
+    end
+
+    def self.put(source_id, params)
+      Api::Request.new(
+        "/harvester/sources/#{source_id}",
+        params
+      ).put
+    end
+
+    def self.link_check_records(source_id)
+      Api::Request.new(
+        "/harvester/sources/#{source_id}/link_check_records"
+      ).get
+    end
+  end
+end

--- a/app/models/harvest_job.rb
+++ b/app/models/harvest_job.rb
@@ -35,9 +35,7 @@ class HarvestJob < AbstractJob
   end
 
   def flush_old_records
-    RestClient.post("#{ENV['API_HOST']}/harvester/records/flush.json",
-                    source_id: source_id, job_id: id,
-                    api_key: ENV['HARVESTER_API_KEY'])
+    Api::Record.flush({ source_id: source_id, job_id: id })
   rescue RestClient::Exception => e
     create_harvest_failure(exception_class: e.class,
                            message: "Flush old records failed with the following error mesage: #{e.message}",

--- a/app/workers/api_delete_worker.rb
+++ b/app/workers/api_delete_worker.rb
@@ -24,12 +24,7 @@ class ApiDeleteWorker < AbstractWorker
 
   def perform(identifier, job_id)
     @job_id = job_id
-    response = RestClient.put(
-      "#{ENV['API_HOST']}/harvester/records/delete",
-      { id: identifier, api_key: ENV['HARVESTER_API_KEY'] },
-      content_type: :json, accept: :json
-    )
-    response = JSON.parse(response)
+    response = JSON.parse(Api::Record.delete(identifier))
 
     process_response(response)
   end

--- a/app/workers/api_update_worker.rb
+++ b/app/workers/api_update_worker.rb
@@ -31,7 +31,8 @@ class ApiUpdateWorker < AbstractWorker
     response = RestClient.post(
       "#{ENV['API_HOST']}#{path}",
       attributes.merge(api_key: ENV['HARVESTER_API_KEY']).to_json,
-      content_type: :json, accept: :json
+      content_type: :json, accept: :json,
+      'Authentication-Token': ENV['HARVESTER_API_KEY']
     )
     response = JSON.parse(response)
 

--- a/app/workers/link_check_worker.rb
+++ b/app/workers/link_check_worker.rb
@@ -93,7 +93,7 @@ class LinkCheckWorker
     end
 
     def set_record_status(record_id, status)
-      RestClient.put("#{ENV['API_HOST']}/harvester/records/#{record_id}", record: { status: status }, api_key: ENV['HARVESTER_API_KEY'])
+      Api::Record.put(record_id, { record: { status: status } })
       add_record_stats(record_id, status)
     rescue StandardError
       Sidekiq.logger.warn('Record not found when updating status in LinkChecking. Ignoring.')

--- a/app/workers/source_check_worker.rb
+++ b/app/workers/source_check_worker.rb
@@ -20,19 +20,13 @@ class SourceCheckWorker
   private
     def source_records
       JSON.parse(
-        RestClient.get(
-          "#{ENV['API_HOST']}/harvester/sources/#{source.id}/link_check_records",
-          params: { api_key: ENV['HARVESTER_API_KEY'] }
-        )
+        Api::Source.link_check_records(source.id)
       )
     end
 
     def source_active?
       collection = JSON.parse(
-        RestClient.get(
-          "#{ENV['API_HOST']}/harvester/sources/#{source.id}",
-          params: { api_key: ENV['HARVESTER_API_KEY'] }
-        )
+        Api::Source.get(source.id)
       )
       collection['status'] == 'active'
     end
@@ -51,19 +45,15 @@ class SourceCheckWorker
     end
 
     def suppress_collection
-      RestClient.put(
-        "#{ENV['API_HOST']}/harvester/sources/#{source.id}",
-        source: { status: 'suppressed', status_updated_by: 'LINK CHECKER' },
-        api_key: ENV['HARVESTER_API_KEY']
+      Api::Source.put(source.id, source:
+        { status: 'suppressed', status_updated_by: 'LINK CHECKER' }
       )
       CollectionMailer.collection_status(source, 'suppressed').deliver
     end
 
     def activate_collection
-      RestClient.put(
-        "#{ENV['API_HOST']}/harvester/sources/#{source.id}",
-        source: { status: 'active', status_updated_by: 'LINK CHECKER' },
-        api_key: ENV['HARVESTER_API_KEY']
+      Api::Source.put(source.id, source:
+        { status: 'active', status_updated_by: 'LINK CHECKER' }
       )
       CollectionMailer.collection_status(source, 'activated').deliver
     end

--- a/spec/api/api/request_spec.rb
+++ b/spec/api/api/request_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::Request do
+  describe '#initialize' do
+    it 'sets the url' do
+      request = described_class.new('/test')
+      expect(request.url).to include(ENV['API_HOST'])
+    end
+
+    it 'appends .json to the path' do
+      request = described_class.new('/test')
+      expect(request.url).to end_with('/test.json')
+    end
+
+    it 'stores the token' do
+      request = described_class.new('/test')
+      expect(request.token).to include(ENV['HARVESTER_API_KEY'])
+    end
+
+    it 'stores the params ready to be used by RestClient if present' do
+      request = described_class.new('/test', { param: :value })
+      expect(request.params).to eq(param: :value)
+    end
+
+    it 'stores the params as empty hash if not present' do
+      request = described_class.new('/test')
+      expect(request.params).to eq({})
+    end
+  end
+
+  %i[get post put patch delete].each do |method|
+    describe "##{method}" do
+      it "only calls execute with the #{method} method" do
+        request = described_class.new('/test')
+        expect(request).to receive(:execute).with(method)
+        request.send(method)
+      end
+    end
+  end
+
+  describe '#execute' do
+    it 'sends the right method' do
+      request = described_class.new('/test')
+      expect(RestClient::Request).to receive(:execute).with(hash_including(method: :get))
+      request.get
+
+      request = described_class.new('/test')
+      expect(RestClient::Request).to receive(:execute).with(hash_including(method: :put))
+      request.put
+    end
+
+    it 'sends to the set url' do
+      request = described_class.new('/test')
+      expect(RestClient::Request).to receive(:execute).with(hash_including(url: request.url))
+      request.get
+    end
+
+    it 'sends the Authentication-Token header' do
+      request = described_class.new('/test')
+      expect(RestClient::Request).to receive(:execute).with(hash_including(
+        headers: { 'Authentication-Token': request.token }
+      ))
+      request.get
+    end
+  end
+end

--- a/spec/models/harvest_job_spec.rb
+++ b/spec/models/harvest_job_spec.rb
@@ -72,8 +72,12 @@ describe HarvestJob do
   describe '#flush_old_records' do
     it 'post to the apis /harvester/records/flush action with source_id and the harvest_job_id' do
       allow(job).to receive(:source_id).and_return('source_id')
-      expect(RestClient).to receive(:post).with("#{ENV['API_HOST']}/harvester/records/flush.json", source_id: 'source_id', job_id: job.id,
-api_key: ENV['HARVESTER_API_KEY'])
+      expect(RestClient::Request).to receive(:execute).with(
+        method: :post,
+        url: "#{ENV['API_HOST']}/harvester/records/flush.json",
+        payload: { source_id: 'source_id', job_id: job.id },
+        headers: { 'Authentication-Token': ENV['HARVESTER_API_KEY'] }
+      )
       job.flush_old_records
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -57,6 +57,8 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
+  config.example_status_persistence_file_path = 'spec/examples.txt'
+
   # The settings below are suggested to provide a good initial experience
   # with RSpec, but feel free to customize to your heart's content.
   #   # This allows you to limit a spec run to individual examples or groups

--- a/spec/workers/api_delete_worker_spec.rb
+++ b/spec/workers/api_delete_worker_spec.rb
@@ -33,13 +33,17 @@ describe ApiDeleteWorker do
     end
 
     it 'put attributes to the api' do
-      expect(RestClient).to receive(:put).and_return(success_response.to_json)
+      expect(RestClient::Request).to receive(:execute)
+        .with(hash_including(method: :put))
+        .and_return(success_response.to_json)
       worker.perform('/harvester/records/123/fragments.json', {})
     end
 
     context 'API return a status: :failed' do
       before(:each) do
-        allow(RestClient).to receive(:put).and_return(failed_response.to_json)
+        allow(RestClient::Request).to receive(:execute)
+          .with(hash_including(method: :put))
+          .and_return(failed_response.to_json)
       end
 
       it 'triggers an ElasticAPM notification' do
@@ -61,7 +65,9 @@ describe ApiDeleteWorker do
 
     context 'API return a status: :success' do
       before(:each) do
-        allow(RestClient).to receive(:put).and_return(success_response.to_json)
+        allow(RestClient::Request).to receive(:execute)
+          .with(hash_including(method: :put))
+          .and_return(success_response.to_json)
       end
 
       it 'increments job.posted_records_count' do

--- a/spec/workers/link_check_worker_spec.rb
+++ b/spec/workers/link_check_worker_spec.rb
@@ -164,9 +164,13 @@ describe LinkCheckWorker do
     before { allow(RestClient).to receive(:put) }
     after { worker.send(:set_record_status, '123', 'deleted') }
 
-    it 'makes a http PUT call with restclinet to the API_HOST' do
-      expect(RestClient).to receive(:put).with("#{ENV['API_HOST']}/harvester/records/123",
-                                               record: { status: 'deleted' }, api_key: ENV['HARVESTER_API_KEY'])
+    it 'makes a http PUT call with RestClient to the API_HOST' do
+      expect(RestClient::Request).to receive(:execute).with(
+        method: :put,
+        url: "#{ENV['API_HOST']}/harvester/records/123.json",
+        payload: { record: { status: 'deleted' } },
+        headers: { 'Authentication-Token': ENV['HARVESTER_API_KEY'] }
+      )
     end
   end
 
@@ -228,8 +232,12 @@ describe LinkCheckWorker do
     before { allow(RestClient).to receive(:put) }
 
     it 'should make a post to the api to change the status to supressed for the record' do
-      expect(RestClient).to receive(:put).with("#{ENV['API_HOST']}/harvester/records/abc123", record: { status: 'suppressed' },
-api_key: ENV['HARVESTER_API_KEY'])
+      expect(RestClient::Request).to receive(:execute).with(
+        method: :put,
+        url: "#{ENV['API_HOST']}/harvester/records/abc123.json",
+        payload: { record: { status: 'suppressed' } },
+        headers: { 'Authentication-Token': ENV['HARVESTER_API_KEY'] }
+      )
       worker.send(:suppress_record, link_check_job.id.to_s, 'abc123', 0)
     end
 


### PR DESCRIPTION
[API KEY IN HEADER FOR SJ WORKER: As Sasha, I want Supplejack Worker to use HTTP-header based authentication for making API requests, so that the API keys are kept secret.](https://www.pivotaltracker.com/story/show/179971642)

STORY
=====

**Acceptance Criteria**
- Supplejack Worker passes API Key in the HTTP Header, and not in the URL
