### PR TITLE
SJ IMPROVE ENRICHMENT PREVIEW PROCESS: As Tim I want enrichment preview process improved, so that developing and troubleshooting enrichments is easy and reliable with useful feedback

### DIFF
--- a/app/jobs/preview_start_job.rb
+++ b/app/jobs/preview_start_job.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-class PreviewStartJob < ApplicationJob
-  queue_as :default
-
-  def perform(parser_id)
-    @preview = Preview.find(parser_id).spawn_preview_worker
-  end
-end

--- a/app/models/enrichment_failure.rb
+++ b/app/models/enrichment_failure.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# app/models/harvest_failure.rb
+class EnrichmentFailure
+  include Mongoid::Document
+  include Mongoid::Timestamps
+  include Mongoid::Attributes::Dynamic
+
+  field :exception_class, type: String
+  field :message,         type: String
+  field :backtrace,       type: Array
+
+  embedded_in :enrichment_job
+end

--- a/app/models/enrichment_job.rb
+++ b/app/models/enrichment_job.rb
@@ -8,6 +8,7 @@ class EnrichmentJob < AbstractJob
 
   field :enrichment,  type: String
   field :record_id,   type: Integer
+  embeds_one :enrichment_failure
 
   validates :record_id, numericality: { other_than: 0, allow_nil: true, message: 'record_id cannot be zero' }
   validates_uniqueness_of :enrichment,

--- a/app/models/preview.rb
+++ b/app/models/preview.rb
@@ -18,6 +18,7 @@ class Preview < ActiveResource::Base
     attribute :validation_errors,      :string
     attribute :harvest_failure,        :string
     attribute :harvest_job_errors,     :string
+    attribute :enrichment_failures,    :string
     attribute :format,                 :string
   end
 end

--- a/spec/workers/preview_worker_spec.rb
+++ b/spec/workers/preview_worker_spec.rb
@@ -7,12 +7,12 @@ describe PreviewWorker do
  Parser.new(strategy: 'xml', name: 'Natlib Pages', content: 'class NatlibPages < SupplejackCommon::Xml::Base; end', file_name: 'natlib_pages.rb',
 source: { source_id: 'source_id' }) }
   let(:job) { HarvestJob.new(environment: 'preview', parser_id: 'abc123', index: 3, harvest_failure: {}, last_posted_record_id: 1234) }
-  let(:preview) { mock_model(Preview, _id: '123').as_null_object }
+  let(:preview) { mock_model(Preview, _id: '123', enrichment_failures: nil).as_null_object }
 
   let(:worker) { PreviewWorker.new }
 
   let(:record1) {
- double(:record, raw_data: '{"id": "123"}', attributes: { title: 'Clip the dog', data_type: 'record' }, field_errors: {}, validation_errors: {}) }
+  double(:record, raw_data: '{"id": "123"}', attributes: { title: 'Clip the dog', data_type: 'record' }, field_errors: {}, validation_errors: {}) }
   let(:record2) { double(:record) }
 
   before do


### PR DESCRIPTION
[SJ IMPROVE ENRICHMENT PREVIEW PROCESS: As Tim I want enrichment preview process improved, so that developing and troubleshooting enrichments is easy and reliable with useful feedback](https://www.pivotaltracker.com/story/show/180640850)

STORY
=====

**Acceptance Criteria**
- Enrichment process is captured in preview reliably!
- Failures are captured/presented

**Risks**
- ?

**Notes**
- Following Eddy's story https://www.pivotaltracker.com/story/show/108033670:
>Issues with Enrichment
Enrichment is a background job triggered within a background job. Current enrichment worker is not designed to effectively return any information to a preview, it just starts and ends. This can be fixed but will require adding more functionalities to the existing enrichment worker.
- Enrichments previews should run in the same way with the same level and method of feed back to the user
- Test below fails informatively, rather than silently

**Tests**
- Enrichments fail silently and strangely (in a confusing cached way)
 - Load [this parser version](https://manager.digitalnz.org/parsers/558b3bea297b1fc90f000003/versions/61a533c471cffd0009b2365f)
 - Preview as is, checking the enrichment worked
 - Then make the 2 changes mentioned on line 53
 - Preview again and notice the enrichment will silently fail and show the previous preview result.
