### PR TITLE
FIX SIDEKIQ WARNING: As Dan, I want us to enable `Sidekiq.strict_args!`, so that we don't get the warning filling our logs and we are ready for Sidekiq 7

### DIFF
--- a/app/models/matcher/concept_matcher.rb
+++ b/app/models/matcher/concept_matcher.rb
@@ -56,7 +56,7 @@ module Matcher
           match_status: 'strong'
         }
 
-        ApiUpdateWorker.perform_async('/harvester/concepts.json', { concept: post_attributes }, args[:job_id])
+        ApiUpdateWorker.perform_async('/harvester/concepts.json', { concept: post_attributes }.as_json, args[:job_id])
         true
       end
   end

--- a/app/workers/api_update_worker.rb
+++ b/app/workers/api_update_worker.rb
@@ -23,7 +23,6 @@ class ApiUpdateWorker < AbstractWorker
   end
 
   def perform(path, attributes, job_id)
-    
     @job_id = job_id
     return if stop_harvest?
 

--- a/app/workers/api_update_worker.rb
+++ b/app/workers/api_update_worker.rb
@@ -23,6 +23,7 @@ class ApiUpdateWorker < AbstractWorker
   end
 
   def perform(path, attributes, job_id)
+    
     @job_id = job_id
     return if stop_harvest?
 

--- a/app/workers/enrichment_worker.rb
+++ b/app/workers/enrichment_worker.rb
@@ -162,11 +162,12 @@ class EnrichmentWorker < AbstractWorker
     def post_to_api(enrichment)
       enrichment.record_attributes.as_json.each do |mongo_record_id, attributes|
         attrs = attributes.merge(job_id: job.id.to_s)
+
         ApiUpdateWorker.perform_async(
           "/harvester/records/#{mongo_record_id}/fragments.json", {
             fragment: attrs,
             required_fragments: job.required_enrichments
-          },
+          }.as_json,
           job.id.to_s
         )
         job.increment_records_count!

--- a/app/workers/harvest_worker.rb
+++ b/app/workers/harvest_worker.rb
@@ -82,10 +82,10 @@ class HarvestWorker < AbstractWorker
     attributes.delete(:match_concepts)
 
     if async
-      ApiUpdateWorker.perform_async(path, { data_type => attributes, required_fragments: job.required_enrichments }, job.id.to_s)
+      ApiUpdateWorker.perform_async(path, { data_type => attributes, required_fragments: job.required_enrichments }.as_json, job.id.to_s)
     else
       api_update_worker = ApiUpdateWorker.new
-      api_update_worker.perform(path, { data_type => attributes, required_fragments: job.required_enrichments }, job.id.to_s)
+      api_update_worker.perform(path, { data_type => attributes, required_fragments: job.required_enrichments }.as_json, job.id.to_s)
     end
   end
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -12,6 +12,8 @@ Sidekiq.configure_client do |config|
   config.redis = { url: ENV['REDIS_URL'] }
 end
 
+Sidekiq.strict_args!
+
 
 # # Uncommment if you need to add HTTP Auth to Sidekiq dashboard
 # require 'sidekiq'


### PR DESCRIPTION
**Acceptance Criteria**
- enable the `Sidekiq.strict_args!` worker and API sidekiq
- Sidekiq warning goes away
- check if this effects NatLib 

**Risks**
- The logs get spammed too much in the meantime and cause problems

**Notes**
- Getting a lot of these warnings in our logs
>{"log":"{\"ts\":\"2022-02-09T02:05:23.581Z\",\"pid\":1,\"tid\":\"fn35\",\"lvl\":\"WARN\",\"msg\":\"Job arguments to ApiUpdateWorker do not serialize to JSON safely. This will raise an error in\\nSidekiq 7.0. See https://github.com/mperham/sidekiq/wiki/Best-Practices or raise an error today\\nby calling `Sidekiq.strict_args!` during Sidekiq initialization.\\n\",\"ctx\":{\"class\":\"HarvestWorker\",\"jid\":\"ea331ff0c6220e6e73fb013c\"}}\n","stream":"stdout","time":"2022-02-09T02:05:23.582120006Z"}
- Started around 9:30am Wed the 9th Feb 2022. Maybe with this deploy
https://digitalnz.slack.com/archives/C01A3JQCFMW/p1644351977363449
[production] worker - v2-12-7 ed2291b - Paul Mesnilgrente - deployment successfull
- 
