### PR TITLE
FIX: SJ 'ALL' JOBS PAGINATION BROKEN

### DIFF
--- a/app/controllers/abstract_jobs_controller.rb
+++ b/app/controllers/abstract_jobs_controller.rb
@@ -7,26 +7,25 @@ class AbstractJobsController < ApplicationController
   def index
     @abstract_jobs = AbstractJob.search(search_params)
 
-    header_values = {
-      'X-total' => :total_count,
-      'X-offset' => :offset_value,
-      'X-limit' => :limit_value
-    }
-
-    header_values.each do |header, value|
+    headers_and_values_for_pagination.each do |header, value|
       response.headers[header] = @abstract_jobs.send(value).to_s
     end
-
 
     render json: @abstract_jobs
   end
 
-  # def jobs_since
-  #   render json: AbstractJob.jobs_since(search_params)
-  # end
+  def jobs_since
+    render json: AbstractJob.jobs_since(search_params)
+  end
 
   private
     def search_params
       params.permit(:status, :environment, :parser_id, :datetime, :page)
+    end
+
+    def headers_and_values_for_pagination
+      { 'X-total' => :total_count,
+        'X-offset' => :offset_value,
+        'X-limit' => :limit_value }
     end
 end

--- a/app/controllers/abstract_jobs_controller.rb
+++ b/app/controllers/abstract_jobs_controller.rb
@@ -7,19 +7,23 @@ class AbstractJobsController < ApplicationController
   def index
     @abstract_jobs = AbstractJob.search(search_params)
 
-    headers = ['X-total', 'X-offset', 'X-limit']
-    values = %i[total_count offset_value limit_value]
+    header_values = {
+      'X-total' => :total_count,
+      'X-offset' => :offset_value,
+      'X-limit' => :limit_value
+    }
 
-    headers.zip(values) do |header, value|
+    header_values.each do |header, value|
       response.headers[header] = @abstract_jobs.send(value).to_s
     end
+
 
     render json: @abstract_jobs
   end
 
-  def jobs_since
-    render json: AbstractJob.jobs_since(search_params)
-  end
+  # def jobs_since
+  #   render json: AbstractJob.jobs_since(search_params)
+  # end
 
   private
     def search_params

--- a/app/models/abstract_job.rb
+++ b/app/models/abstract_job.rb
@@ -49,7 +49,7 @@ class AbstractJob
     valid_fields = %i[status environment parser_id]
 
     page = search_params.delete(:page) || 1
-    amount = search_params.delete(:limit) || 50
+    limit = search_params.delete(:limit) || 50
 
     search_params.delete_if { |key, _value| !valid_fields.include?(key) }
 
@@ -62,9 +62,7 @@ class AbstractJob
       end
     end
 
-    scope = scope.where(search_params)
-    scope = scope.limit(amount.to_i) if amount
-    scope
+    scope.where(search_params).limit(limit.to_i).to_a
   end
 
   def self.clear_raw_data

--- a/app/models/abstract_job.rb
+++ b/app/models/abstract_job.rb
@@ -45,24 +45,21 @@ class AbstractJob
   scope :disposable, -> { lt(created_at: Time.zone.now - 3.months) }
 
   def self.search(params)
-    search_params = params.to_h.try(:symbolize_keys) || {}
-    valid_fields = %i[status environment parser_id]
+    params = params.to_h.try(:symbolize_keys) || {}
+    page = params.delete(:page) || 1
+    limit = params.delete(:limit) || 50
+    scope = self.page(page.to_i)
 
-    page = search_params.delete(:page) || 1
-    limit = search_params.delete(:limit) || 50
+    params.delete_if { |key, _value| %i[status environment parser_id].exclude?(key) }
 
-    search_params.delete_if { |key, _value| !valid_fields.include?(key) }
-
-    scope = self.page(page.to_i).desc(:start_time)
-
-    search_params.each_pair do |attribute, value|
+    params.each_pair do |attribute, value|
       if value.is_a?(Array)
         scope = scope.in(attribute => value)
-        search_params.delete(attribute)
+        params.delete(attribute)
       end
     end
 
-    scope.where(search_params).limit(limit.to_i).to_a
+    scope.where(params).limit(limit.to_i).desc(:created_at)
   end
 
   def self.clear_raw_data

--- a/app/models/abstract_job.rb
+++ b/app/models/abstract_job.rb
@@ -49,7 +49,7 @@ class AbstractJob
     valid_fields = %i[status environment parser_id]
 
     page = search_params.delete(:page) || 1
-    amount = search_params.delete(:limit) || nil
+    amount = search_params.delete(:limit) || 50
 
     search_params.delete_if { |key, _value| !valid_fields.include?(key) }
 

--- a/spec/controllers/abstract_jobs_controller_spec.rb
+++ b/spec/controllers/abstract_jobs_controller_spec.rb
@@ -4,32 +4,38 @@ require 'rails_helper'
 
 describe AbstractJobsController do
   describe 'GET index' do
-    before(:each) do
-      request.headers['Authorization'] = "Token token=#{ENV['WORKER_KEY']}"
-      mock_obj = double(total_count: 45, offset_value: 0, limit_value: 20)
-      allow(AbstractJob).to receive(:search).and_return(mock_obj)
+    context 'when worker_key is not provided' do
+      it 'returns unauthorized' do
+        get :index, params: { status: 'active' }
+
+        expect(response).to be_unauthorized
+      end
     end
 
-    it 'returns active abstract jobs' do
-      allow(AbstractJob).to receive(:search).with(
-        hash_including('status' => 'active')
-      ).and_call_original
+    context 'when worker_key is provided' do
+      before do
+        request.headers['Authorization'] = "Token token=#{ENV['WORKER_KEY']}"
 
-      get :index, params: { status: 'active' }
+        allow(AbstractJob)
+          .to receive(:search)
+          .and_return(double(total_count: 45, offset_value: 0, limit_value: 20))
+      end
+
+      it 'returns active abstract jobs' do
+        allow(AbstractJob).to receive(:search).with(
+          hash_including('status' => 'active')
+        ).and_call_original
+
+        get :index, params: { status: 'active' }
+      end
+
+      it 'should set pagination headers' do
+        get :index, params: { status: 'active' }
+
+        expect(response.headers['X-total']).to eq '45'
+        expect(response.headers['X-offset']).to eq '0'
+        expect(response.headers['X-limit']).to eq '20'
+      end
     end
-
-    it 'should set pagination headers' do
-      get :index, params: { status: 'active' }
-
-      expect(response.headers['X-total']).to eq '45'
-      expect(response.headers['X-offset']).to eq '0'
-      expect(response.headers['X-limit']).to eq '20'
-    end
-  end
-
-  it 'prevent access if worker_key is not provided' do
-    get :index, params: { status: 'active' }
-
-    expect(response.status).to eq(401)
   end
 end

--- a/spec/controllers/abstract_jobs_controller_spec.rb
+++ b/spec/controllers/abstract_jobs_controller_spec.rb
@@ -14,11 +14,13 @@ describe AbstractJobsController do
       allow(AbstractJob).to receive(:search).with(
         hash_including('status' => 'active')
       ).and_call_original
+
       get :index, params: { status: 'active' }
     end
 
     it 'should set pagination headers' do
       get :index, params: { status: 'active' }
+
       expect(response.headers['X-total']).to eq '45'
       expect(response.headers['X-offset']).to eq '0'
       expect(response.headers['X-limit']).to eq '20'
@@ -27,6 +29,7 @@ describe AbstractJobsController do
 
   it 'prevent access if worker_key is not provided' do
     get :index, params: { status: 'active' }
+
     expect(response.status).to eq(401)
   end
 end


### PR DESCRIPTION
**Issue** 
Requests to index was raising `[96:OperationFailed]: Executor error during find command :: caused by :: Sort operation` error.

**Cause**
Search results where sorted with `desc(:start_time)`. start_time is not indexed which caused the issue.

**Fix**
using `created_at` instead. This field is already indexed.

**Note**
Controller and the method is refactored as they were written 9 years back and have remained untouched and some of the business logic wasnt clear.