### PR TITLE
FIX RECORDS NOT BEING INDEXED ISSUE: : As Haki the harvester, I want harvest and enrichments to index records reliably every time, so that i can be confident changes in records will show up in search results

### DIFF
--- a/app/controllers/link_check_jobs_controller.rb
+++ b/app/controllers/link_check_jobs_controller.rb
@@ -2,6 +2,8 @@
 
 # app/controllers/link_check_jobs_controller.rb
 class LinkCheckJobsController < ApplicationController
+  before_action :authenticate_user!
+
   def create
     @job = LinkCheckJob.new(link_check_params)
 

--- a/app/models/abstract_job.rb
+++ b/app/models/abstract_job.rb
@@ -223,4 +223,8 @@ class AbstractJob
     return if states.count <= 5
     states.first.destroy!
   end
+
+  def source_id
+    parser.source.source_id
+  end
 end

--- a/app/models/harvest_job.rb
+++ b/app/models/harvest_job.rb
@@ -82,10 +82,6 @@ class HarvestJob < AbstractJob
     ElasticAPM.report(e)
   end
 
-  def source_id
-    parser.source.source_id
-  end
-
   def finish!
     flush_old_records if full_and_flush_available?
     super

--- a/app/serializers/enrichment_job_serializer.rb
+++ b/app/serializers/enrichment_job_serializer.rb
@@ -22,6 +22,7 @@ class EnrichmentJobSerializer < ActiveModel::Serializer
     processed_count
     record_id
     last_posted_record_id
+    source_id
   ]
 
   # attribute starting with _ does not get serialized via attributes eg :_type

--- a/app/serializers/enrichment_job_serializer.rb
+++ b/app/serializers/enrichment_job_serializer.rb
@@ -2,9 +2,27 @@
 
 # app/serializers/enrichment_job_serializer.rb
 class EnrichmentJobSerializer < ActiveModel::Serializer
-  attributes :id, :start_time, :end_time, :records_count, :throughput
-  attributes :created_at, :updated_at, :duration, :status, :status_message, :user_id, :parser_id, :version_id, :environment, :enrichment
-  attributes :posted_records_count, :processed_count, :record_id, :last_posted_record_id
+  attributes %i[
+    id
+    start_time
+    end_time
+    records_count
+    throughput
+    created_at
+    updated_at
+    duration
+    status
+    status_message
+    user_id
+    parser_id
+    version_id
+    environment
+    enrichment
+    posted_records_count
+    processed_count
+    record_id
+    last_posted_record_id
+  ]
 
   # attribute starting with _ does not get serialized via attributes eg :_type
   # that's why we had to explicity define the attribute here

--- a/app/serializers/failed_record_serializer.rb
+++ b/app/serializers/failed_record_serializer.rb
@@ -2,5 +2,11 @@
 
 # app/serializer/failed_record_serializer.rb
 class FailedRecordSerializer < ActiveModel::Serializer
-  attributes :exception_class, :message, :backtrace, :raw_data, :created_at
+  attributes %i[
+    exception_class
+    message
+    backtrace
+    raw_data
+    created_at
+  ]
 end

--- a/app/serializers/harvest_job_serializer.rb
+++ b/app/serializers/harvest_job_serializer.rb
@@ -24,6 +24,7 @@ class HarvestJobSerializer < ActiveModel::Serializer
     posted_records_count
     retried_records_count
     last_posted_record_id
+    source_id
   ]
 
   # attribute starting with _ does not get serialized via attributes eg :_type

--- a/app/serializers/harvest_job_serializer.rb
+++ b/app/serializers/harvest_job_serializer.rb
@@ -2,10 +2,29 @@
 
 # app/serializer/harvest_job_serializer.rb
 class HarvestJobSerializer < ActiveModel::Serializer
-  attributes :id, :start_time, :end_time, :records_count, :throughput
-  attributes :created_at, :updated_at, :duration, :status, :status_message, :user_id, :parser_id, :version_id, :environment
-  attributes :failed_records_count, :invalid_records_count, :harvest_schedule_id,
-             :mode, :posted_records_count, :retried_records_count, :last_posted_record_id
+  attributes %i[
+    id
+    start_time
+    end_time
+    records_count
+    throughput
+    created_at
+    updated_at
+    duration
+    status
+    status_message
+    user_id
+    parser_id
+    version_id
+    environment
+    failed_records_count
+    invalid_records_count
+    harvest_schedule_id
+    mode
+    posted_records_count
+    retried_records_count
+    last_posted_record_id
+  ]
 
   # attribute starting with _ does not get serialized via attributes eg :_type
   # that's why we had to explicity define the attribute here

--- a/app/serializers/harvest_schedule_serializer.rb
+++ b/app/serializers/harvest_schedule_serializer.rb
@@ -2,9 +2,23 @@
 
 # app/serializers/harvest_schedule_serializer.rb
 class HarvestScheduleSerializer < ActiveModel::Serializer
-  attributes :id, :parser_id, :start_time, :cron, :frequency, :at_hour,
-             :at_minutes, :offset, :environment, :next_run_at, :last_run_at,
-             :recurrent, :mode, :enrichments, :status
+  attributes %i[
+    id
+    parser_id
+    start_time
+    cron
+    frequency
+    at_hour
+    at_minutes
+    offset
+    environment
+    next_run_at
+    last_run_at
+    recurrent
+    mode
+    enrichments
+    status
+  ]
 
   def at_hour
     object.at_hour.to_s.rjust(2, '0')

--- a/app/serializers/invalid_record_serializer.rb
+++ b/app/serializers/invalid_record_serializer.rb
@@ -2,5 +2,9 @@
 
 # app/serializers/invalid_record_serializer.rb
 class InvalidRecordSerializer < ActiveModel::Serializer
-  attributes :raw_data, :error_messages, :created_at
+  attributes %i[
+    raw_data
+    error_messages
+    created_at
+  ]
 end

--- a/spec/controllers/link_check_jobs_controller_spec.rb
+++ b/spec/controllers/link_check_jobs_controller_spec.rb
@@ -10,6 +10,7 @@ describe LinkCheckJobsController do
       before do
         # This will stop it from running a sidekiq job
         ENV['LINK_CHECKING_ENABLED'] == 'true'
+        request.headers['Authorization'] = "Token token=#{ENV['WORKER_KEY']}"
         post :create, params: { link_check: attributes }
       end
 
@@ -33,6 +34,7 @@ describe LinkCheckJobsController do
         attributes = attributes_for(:link_check_job)
         attributes[:record_id] = job.record_id
 
+        request.headers['Authorization'] = "Token token=#{ENV['WORKER_KEY']}"
         post :create, params: { link_check: attributes }
       end
 

--- a/spec/serializers/enrichment_job_serializer_spec.rb
+++ b/spec/serializers/enrichment_job_serializer_spec.rb
@@ -6,6 +6,28 @@ describe EnrichmentJobSerializer do
   let!(:enrichment_job) { create(:enrichment_job) }
   let(:serialized) { described_class.new(enrichment_job) }
 
+  before do
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get(
+        "/parsers/#{enrichment_job.parser_id}/versions/#{enrichment_job.version_id}.json",
+        { 'Accept' => 'application/json', 'Authorization' => "Token token=#{ENV['WORKER_KEY']}" },
+        { parser: { source_id: 'response_source_id' } }.to_json,
+        201
+      )
+
+      mock.get(
+        "/parsers/#{enrichment_job.parser_id}.json",
+        { 'Accept' => 'application/json', 'Authorization' => "Token token=#{ENV['WORKER_KEY']}" },
+        { parser: { source: { source_id: 'response_source_id' } } }.to_json,
+        201
+      )
+    end
+  end
+
+  it 'renders the source_id attribute from the parser' do
+    expect(serialized.serializable_hash[:source_id]).to eq 'response_source_id'
+  end
+
   it 'renders _type attribute with proper value' do
     expect(serialized.serializable_hash[:_type]).to eq enrichment_job._type
   end

--- a/spec/serializers/harvest_job_serializer_spec.rb
+++ b/spec/serializers/harvest_job_serializer_spec.rb
@@ -6,6 +6,28 @@ describe HarvestJobSerializer do
   let!(:harvest_job) { create(:harvest_job) }
   let(:serialized) { described_class.new(harvest_job) }
 
+  before do
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get(
+        "/parsers/#{harvest_job.parser_id}/versions/#{harvest_job.version_id}.json",
+        { 'Accept' => 'application/json', 'Authorization' => "Token token=#{ENV['WORKER_KEY']}" },
+        { parser: { source_id: 'response_source_id' } }.to_json,
+        201
+      )
+
+      mock.get(
+        "/parsers/#{harvest_job.parser_id}.json",
+        { 'Accept' => 'application/json', 'Authorization' => "Token token=#{ENV['WORKER_KEY']}" },
+        { parser: { source: { source_id: 'response_source_id' } } }.to_json,
+        201
+      )
+    end
+  end
+
+  it 'renders the source_id attribute from the parser' do
+    expect(serialized.serializable_hash[:source_id]).to eq 'response_source_id'
+  end
+
   it 'renders _type attribute with proper value' do
     expect(serialized.serializable_hash[:_type]).to eq harvest_job._type
   end


### PR DESCRIPTION
[FIX RECORDS NOT BEING INDEXED ISSUE: : As Haki the harvester, I want harvest and enrichments to index records reliably every time, so that i can be confident changes in records will show up in search results](https://www.pivotaltracker.com/story/show/181705435)

STORY
=====

**Acceptance Criteria**
- All records are reliably indexed in all types of harvests
- Full and flush still works from manual and scheduled jobs
- Implement changes proposed in [story](https://www.pivotaltracker.com/story/show/181472631)
 - All harvest jobs gets the source_id of the parser
 - Index processor can get active source_ids

**Risks**
- This is a change to a critical part of the harvesting process. We dont want to stuff it up.

**Notes**
- Previous story https://www.pivotaltracker.com/story/show/181472631
- Pull requests [supplejack_api](https://github.com/DigitalNZ/supplejack_api/pull/295), [worker](https://github.com/DigitalNZ/supplejack_worker/pull/205) & [manager](https://github.com/DigitalNZ/supplejack_manager/pull/250)

**Tests**
- Can track the harvesting logs to see source_ids that are skipped whilst harvest and enrichment in index processor
- [This parser](https://manager.digitalnz.org/parsers/558b3bea297b1fc90f000003/versions/6240deae2607c7000ae72b32) has 2 versions which (in the last enrichment) set the atl_purchasable fields to true or false. After each harvest there should be none left (eg the indexer picks them all up) in the previous states [API request](https://api.staging.digitalnz.org/records.json?api_key=v0aORgQAmQDSPtOJzMGI&and[atl_purchasable_download]=false&and[primary_collection]=TAPUHI&text=source_id_s%3Adave_test&per_page=100&fields=id,internal_identifier,primary_collection,title,large_thumbnail_url,landing_url,updated_at,created_at,tag,atl_purchasable,atl_purchasable_download&page=1&debug=true&facets=atl_purchasable_download).
