### PR TITLE
SJ SCROLL HARVEST: As Tim H, I want Sj to page through a scroll harvest, so that I can harvest from both Auck Museum and Te Papa 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'rails', '~> 7.0.3'
 gem 'responders'
 gem 'sidekiq', '~> 6.4.0'
 gem 'sinatra', require: nil
-gem 'supplejack_common', github: 'DigitalNZ/supplejack_common', branch: 'rm/sj-scroll-harvest'
+gem 'supplejack_common', github: 'DigitalNZ/supplejack_common', tag: 'v2.11'
 gem 'whenever', require: false
 gem 'brakeman'
 gem 'amazing_print'

--- a/Gemfile
+++ b/Gemfile
@@ -21,8 +21,7 @@ gem 'rails', '~> 7.0.3'
 gem 'responders'
 gem 'sidekiq', '~> 6.4.0'
 gem 'sinatra', require: nil
-gem 'supplejack_common', github: 'DigitalNZ/supplejack_common', tag: 'v2.10.8'
-# gem 'supplejack_common', path: '~/webspace/supplejack_common'
+gem 'supplejack_common', github: 'DigitalNZ/supplejack_common', branch: 'rm/sj-scroll-harvest'
 gem 'whenever', require: false
 gem 'brakeman'
 gem 'amazing_print'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DigitalNZ/supplejack_common
-  revision: 117f6bd1d38da4e7bd50d949ac5a29851c6cc220
-  tag: v2.10.8
+  revision: ba5f704a3264aa173babdbd61ff4af56c2b1b28f
+  branch: rm/sj-scroll-harvest
   specs:
     supplejack_common (0.0.2)
       actionpack
@@ -207,7 +207,7 @@ GEM
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     jmespath (1.6.1)
-    json (2.6.2)
+    json (2.6.3)
     jsonapi-renderer (0.2.2)
     jsonpath (0.5.8)
       multi_json
@@ -448,6 +448,7 @@ GEM
 PLATFORMS
   x86_64-darwin-19
   x86_64-darwin-20
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
@@ -493,4 +494,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   2.3.12
+   2.4.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DigitalNZ/supplejack_common
-  revision: 56b914ad6304228b40a921a7f6353c3e865a9a5c
-  branch: rm/sj-scroll-harvest
+  revision: bac9f1ff04d82c8bfee2c7ed8d4ddc53c73b2bd4
+  tag: v2.11
   specs:
     supplejack_common (0.0.2)
       actionpack

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DigitalNZ/supplejack_common
-  revision: ba5f704a3264aa173babdbd61ff4af56c2b1b28f
+  revision: 56b914ad6304228b40a921a7f6353c3e865a9a5c
   branch: rm/sj-scroll-harvest
   specs:
     supplejack_common (0.0.2)

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-plugin 'metrics'
+plugin('metrics') if %w[uat staging production].include? ENV['RAILS_ENV']
 
 # To avoid SIGTERMS on scaledown in ElasticAPM
 # https://www.rubydoc.info/gems/puma/Puma%2FDSL:raise_exception_on_sigterm


### PR DESCRIPTION
Acceptance Criteria

Scroll harvests page through correctly.
Scroll harvests stop at the end of the pages
Risks

Endlessly paging to infinity
Being customisable enough to allow future quirks from the next partner
Notes

The "scroll" method is a standardised way to page through ElasticSearch collections

the init_url allows the search param to change

the scroll=10m param should go on both the init call and each paginate/scroll call

Will Sj naturally and reliably stop paginating/scrolling when it reaches the last page and cant find any records, or do we need to bake in some code to make it happen cleanly.

Example Requests

https://api.aucklandmuseum.com/search/collectionsonline/_search?scroll=10m&q=334
https://api.aucklandmuseum.com/search/_search/scroll/<-scroll_id->?scroll=1m (or customisable to duration=10m)
Impacts

Some API's have a limit for regular API calls but allow deeper pagination using the scroll method